### PR TITLE
Update to ts-code-standards@4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "uuid": "^8.0.0"
       },
       "devDependencies": {
-        "@aligent/ts-code-standards": "^3.0.1",
+        "@aligent/ts-code-standards": "^4.0.0",
         "@babel/preset-env": "^7.26.9",
         "@babel/preset-typescript": "^7.27.0",
         "@openwhisk/wskdebug": "^1.3.0",
@@ -943,21 +943,21 @@
       }
     },
     "node_modules/@aligent/ts-code-standards": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@aligent/ts-code-standards/-/ts-code-standards-3.0.1.tgz",
-      "integrity": "sha512-Lj1+8eLvJ1zw1mbErTkpNOYyX3OUrQ3MnDo+y8823HLQnKgA9HHdcX8T4QPMUoITKu8zcEBnPsazvlfwBH4T6g==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aligent/ts-code-standards/-/ts-code-standards-4.0.0.tgz",
+      "integrity": "sha512-QyB8URtpZ+koVYsjRKpJLF2OOlC0K/jG5nBVKx0P6KzON2AW07V6yHtUm7/TULQmn7kxttmVj2Edw6istMHDGw==",
       "dev": true,
       "dependencies": {
         "@eslint/compat": "^1.2.7",
-        "@eslint/js": "^9.21.0",
-        "eslint-config-prettier": "^10.0.2",
+        "@eslint/js": "^9.23.0",
+        "eslint-config-prettier": "^10.1.1",
         "eslint-plugin-jsx-a11y": "^6.10.2",
-        "eslint-plugin-prettier": "^5.2.3",
+        "eslint-plugin-prettier": "^5.2.5",
         "eslint-plugin-react": "^7.37.4",
         "eslint-plugin-react-hooks": "^5.2.0",
         "prettier-plugin-organize-imports": "^4.1.0",
         "prettier-plugin-tailwindcss": "^0.6.11",
-        "typescript-eslint": "^8.25.0"
+        "typescript-eslint": "^8.29.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "uuid": "^8.0.0"
   },
   "devDependencies": {
-    "@aligent/ts-code-standards": "^3.0.1",
+    "@aligent/ts-code-standards": "^4.0.0",
     "@babel/preset-env": "^7.26.9",
     "@babel/preset-typescript": "^7.27.0",
     "@openwhisk/wskdebug": "^1.3.0",


### PR DESCRIPTION
---

**Description of the proposed changes**

Use the latest version of our code standards.

No need to change the import syntax as this already imports `eslintConfits.react`

**Notes to reviewers**

🛈 When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback
