### PR TITLE
Fix/codeowners syntax

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,5 @@
 # DevOps team owns the .github folder
 .github/ @aligent/devops
 
-# Microservice team own everything else
-* @aligent/microservices
-* @aligent/backends
+# Microservices and Backend teams own everything else
+* @aligent/microservices @aligent/backends

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
-# DevOps team owns the .github folder
-.github/ @aligent/devops
-
 # Microservices and Backend teams own everything else
 * @aligent/microservices @aligent/backends
+
+# DevOps team owns the .github folder
+.github/ @aligent/devops


### PR DESCRIPTION
**Description of the proposed changes**

Makes backend and microservices teams both owners of the repo.

Makes devops ownership of .github folder supercede other ownership.

**Notes to reviewers**

🛈 When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback
