### PR TITLE
Feature/APP-18: Fix alias path configs

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,5 +1,6 @@
 module.exports = {
     moduleNameMapper: {
+        '^@/(.*)$': '<rootDir>/src/$1',
         '^(\\.{1,2}/.*)\\.js$': '$1',
     },
     transform: {

--- a/src/web/src/components/App.tsx
+++ b/src/web/src/components/App.tsx
@@ -1,12 +1,12 @@
 import { defaultTheme, Grid, Provider, View } from '@adobe/react-spectrum';
 import { Route, Routes, useNavigate } from 'react-router';
 
-import { Documentation } from '@/components/Documentation.tsx';
-import { Home } from '@/components/Home.tsx';
-import { SampleAction } from '@/components/SampleAction.tsx';
-import SideBar from '@/components/SideBar.tsx';
-import { AdobeRuntimeContextProvider } from '@/context/AdobeRuntimeContextProvider.tsx';
-import { PageContextProvider } from '@/context/PageContextProvider.tsx';
+import { Documentation } from '@/web/components/Documentation.tsx';
+import { Home } from '@/web/components/Home.tsx';
+import { SampleAction } from '@/web/components/SampleAction.tsx';
+import SideBar from '@/web/components/SideBar.tsx';
+import { AdobeRuntimeContextProvider } from '@/web/context/AdobeRuntimeContextProvider.tsx';
+import { PageContextProvider } from '@/web/context/PageContextProvider.tsx';
 
 function App() {
     const navigate = useNavigate();

--- a/src/web/src/components/Documentation.tsx
+++ b/src/web/src/components/Documentation.tsx
@@ -1,4 +1,5 @@
 import { Content, Heading, Link, View } from '@adobe/react-spectrum';
+
 export const Documentation = () => (
     <View width="size-16000">
         <Heading level={1}>Useful documentation for your app</Heading>

--- a/src/web/src/components/Home.tsx
+++ b/src/web/src/components/Home.tsx
@@ -1,6 +1,6 @@
 import { Heading, Text, View } from '@adobe/react-spectrum';
 
-import { usePageContext } from '@/context/PageContextProvider.tsx';
+import { usePageContext } from '@/web/context/PageContextProvider.tsx';
 
 export const Home = () => {
     const { title } = usePageContext();

--- a/src/web/src/components/SampleAction.tsx
+++ b/src/web/src/components/SampleAction.tsx
@@ -11,9 +11,9 @@ import {
 import Search from '@spectrum-icons/workflow/Search';
 import { useState } from 'react';
 
-import { JsonTree, type Json } from '@/components/JsonTree';
-import { useAdobeRuntimeContext } from '@/context/AdobeRuntimeContextProvider';
-import { useAppBuilderAction } from '@/hooks/useAppBuilderAction';
+import { JsonTree, type Json } from '@/web/components/JsonTree';
+import { useAdobeRuntimeContext } from '@/web/context/AdobeRuntimeContextProvider';
+import { useAppBuilderAction } from '@/web/hooks/useAppBuilderAction';
 
 export const SampleAction = () => {
     // Set up react hook to invoke our appbuilder action

--- a/src/web/src/context/AdobeRuntimeContextProvider.tsx
+++ b/src/web/src/context/AdobeRuntimeContextProvider.tsx
@@ -1,8 +1,8 @@
 import { Runtime } from '@adobe/exc-app';
 import { createContext, useContext, useEffect, useState } from 'react';
 
-import { RuntimeScript, type Ims } from '@/runtime/RuntimeScript';
-import { mockIms, mockRuntime } from '@/runtime/runtimeMocks';
+import { RuntimeScript, type Ims } from '@/web/runtime/RuntimeScript';
+import { mockIms, mockRuntime } from '@/web/runtime/runtimeMocks';
 
 const AdobeRuntimeContext = createContext<AdobeRuntimeContextType>({
     loading: true,

--- a/src/web/src/context/PageContextProvider.tsx
+++ b/src/web/src/context/PageContextProvider.tsx
@@ -2,7 +2,7 @@ import page from '@adobe/exc-app/page';
 import topbar from '@adobe/exc-app/topbar';
 import { createContext, useContext, useEffect } from 'react';
 
-import { useAdobeRuntimeContext } from '@/context/AdobeRuntimeContextProvider';
+import { useAdobeRuntimeContext } from '@/web/context/AdobeRuntimeContextProvider';
 
 interface PageContextType {
     title: string;

--- a/src/web/src/hooks/useAppBuilderAction.ts
+++ b/src/web/src/hooks/useAppBuilderAction.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react';
 
-import ActionRegistry from '@/config.json';
+import ActionRegistry from '@/web/config.json';
 
 export interface UseAppBuilderActionOptions {
     name: keyof typeof ActionRegistry;

--- a/src/web/src/index.tsx
+++ b/src/web/src/index.tsx
@@ -1,7 +1,7 @@
 import { createRoot } from 'react-dom/client';
 import { HashRouter } from 'react-router';
 
-import App from '@/components/App.tsx';
+import App from '@/web/components/App.tsx';
 
 import './index.css';
 

--- a/src/web/src/runtime/runtimeMocks.ts
+++ b/src/web/src/runtime/runtimeMocks.ts
@@ -1,6 +1,6 @@
 import type { Runtime } from '@adobe/exc-app';
 
-import type { Ims } from '@/runtime/RuntimeScript';
+import type { Ims } from '@/web/runtime/RuntimeScript';
 
 /**
  * Mock runtime object provided when running outside

--- a/src/web/tsconfig.json
+++ b/src/web/tsconfig.json
@@ -3,8 +3,9 @@
     "compilerOptions": {
         "allowImportingTsExtensions": true,
         "resolveJsonModule": true,
-        "baseUrl": "./src",
+        "baseUrl": "..",
         "paths": {
+            "@/web/*": ["web/src/*"],
             "@/*": ["*"]
         }
     },

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,5 +1,13 @@
 {
     "extends": "../tsconfig.base.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "allowImportingTsExtensions": true,
+        "baseUrl": "..",
+        "paths": {
+            "@/*": ["src/*"]
+        },
+    },
     "include": ["**/*.test.ts", "../global-types"],
     "exclude": []
 }

--- a/tests/unit/api-sample.test.ts
+++ b/tests/unit/api-sample.test.ts
@@ -59,16 +59,15 @@ const fakeParams = {
     __ow_query: '',
     name: 'fake',
     BASE_URL: 'http://fake-url.com/get/',
-    LOG_LEVEL: 'fakeLevel',
 };
 
 describe('api-sample', () => {
     test('main should be defined', () => {
         expect(action.main).toBeInstanceOf(Function);
     });
-    test('should set logger to use LOG_LEVEL param', async () => {
-        await action.main(fakeParams);
-        expect(loggerSpy).toHaveBeenCalledWith(expect.any(String), { level: 'fakeLevel' });
+    test('should set logger to use LOG_LEVEL param when it is provided', async () => {
+        await action.main({ ...fakeParams, LOG_LEVEL: 'debug' });
+        expect(loggerSpy).toHaveBeenCalledWith(expect.any(String), { level: 'debug' });
     });
     test('should return an http reponse with the fetched content', async () => {
         const response = await action.main(fakeParams);

--- a/tests/unit/publish-event-sample.test.ts
+++ b/tests/unit/publish-event-sample.test.ts
@@ -45,16 +45,15 @@ const fakeParams = {
     providerId: 'fakeProvider',
     eventCode: 'fakeEventCode',
     payload: { hello: 'world' },
-    LOG_LEVEL: 'fakeLevel',
 };
 
 describe('publish-event-sample', () => {
     test('main should be defined', () => {
         expect(action.main).toBeInstanceOf(Function);
     });
-    test('should set logger to use LOG_LEVEL param', async () => {
-        await action.main(fakeParams);
-        expect(loggerSpy).toHaveBeenCalledWith(expect.any(String), { level: 'fakeLevel' });
+    test('should set logger to use LOG_LEVEL param when it is provided', async () => {
+        await action.main({ ...fakeParams, LOG_LEVEL: 'debug' });
+        expect(loggerSpy).toHaveBeenCalledWith(expect.any(String), { level: 'debug' });
     });
     test('events sdk should be initialized with input credentials', async () => {
         await action.main(fakeParams);


### PR DESCRIPTION
## Description of the proposed changes
* Fixed import path alias configs introduced from [my previous PR](https://github.com/aligent/appbuilder-typescript-template/pull/13):
  - After my previous changes, we couldn't import items from the `actions` folder inside the `web` folder, because it's nested and its `tsconfig` specifies that the `web` folder is the root. After this change, we can import items from the `actions` folder inside the `web` folder, and it's now clearer that an import is from `web` because it will start with `@/web/...`.
* Setup import path alias for tests,
* Fixed tests that are using `LOG_LEVEL`.
  - I've changed the type for `LOG_LEVEL` in my previous PR, but forgot to update the tests.

## Notes to reviewers
🛈 When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback
