### PR TITLE
Feature/APP-18: `useAppBuilderAction` hook improvements

### DIFF
--- a/src/web/src/components/SampleAction.tsx
+++ b/src/web/src/components/SampleAction.tsx
@@ -13,7 +13,7 @@ import { useState } from 'react';
 
 import { JsonTree, type Json } from '@/components/JsonTree';
 import { useAdobeRuntimeContext } from '@/context/AdobeRuntimeContextProvider';
-import { useLazyAppBuilderAction } from '@/hooks/useLazyAppBuilderAction';
+import { useLazyAppBuilderAction } from '@/hooks';
 
 export const SampleAction = () => {
     // Set up react hook to invoke our appbuilder action

--- a/src/web/src/components/SampleAction.tsx
+++ b/src/web/src/components/SampleAction.tsx
@@ -13,12 +13,12 @@ import { useState } from 'react';
 
 import { JsonTree, type Json } from '@/components/JsonTree';
 import { useAdobeRuntimeContext } from '@/context/AdobeRuntimeContextProvider';
-import { useAppBuilderAction } from '@/hooks/useAppBuilderAction';
+import { useLazyAppBuilderAction } from '@/hooks/useLazyAppBuilderAction';
 
 export const SampleAction = () => {
     // Set up react hook to invoke our appbuilder action
     const { ims } = useAdobeRuntimeContext();
-    const { response, loading, error, invoke } = useAppBuilderAction<Json>({
+    const { response, loading, error, invoke } = useLazyAppBuilderAction<Json>({
         name: 'appbuilder/api-sample',
         method: 'GET',
         ims,

--- a/src/web/src/components/SampleAction.tsx
+++ b/src/web/src/components/SampleAction.tsx
@@ -13,7 +13,7 @@ import { useState } from 'react';
 
 import { JsonTree, type Json } from '@/web/components/JsonTree';
 import { useAdobeRuntimeContext } from '@/web/context/AdobeRuntimeContextProvider';
-import { useLazyAppBuilderAction } from '@/web/hooks';
+import { useLazyAppBuilderAction } from '@/web/hooks/useLazyAppBuilderAction';
 
 export const SampleAction = () => {
     // Set up react hook to invoke our appbuilder action

--- a/src/web/src/hooks/index.ts
+++ b/src/web/src/hooks/index.ts
@@ -1,0 +1,8 @@
+/**
+ * App Builder Action Hooks
+ *
+ * - `useAppBuilderAction`: Invokes the action immediately on mount (eager)
+ * - `useLazyAppBuilderAction`: Returns an `invoke` function for manual triggering (lazy)
+ */
+export * from './useAppBuilderAction';
+export * from './useLazyAppBuilderAction';

--- a/src/web/src/hooks/index.ts
+++ b/src/web/src/hooks/index.ts
@@ -1,8 +1,0 @@
-/**
- * App Builder Action Hooks
- *
- * - `useAppBuilderAction`: Invokes the action immediately on mount (eager)
- * - `useLazyAppBuilderAction`: Returns an `invoke` function for manual triggering (lazy)
- */
-export * from './useAppBuilderAction';
-export * from './useLazyAppBuilderAction';

--- a/src/web/src/hooks/useAppBuilderAction.ts
+++ b/src/web/src/hooks/useAppBuilderAction.ts
@@ -1,0 +1,60 @@
+import { useEffect, useRef, useState } from 'react';
+
+import {
+    useLazyAppBuilderAction,
+    UseLazyAppBuilderActionOptions,
+} from '@/hooks/useLazyAppBuilderAction';
+
+/**
+ * A React hook for invoking App Builder actions with built-in state management. The hook invokes the action
+ * immediately on mount.
+ *
+ * This hook provides a convenient way to call registered App Builder actions with automatic handling of loading states,
+ * errors, and response data. It supports Adobe IMS authentication and allows configuration at both initialization and
+ * invocation time.
+
+ * @example
+ * ```tsx
+ * // Invoke immediately on mount to fetch initial data
+ * const { response, loading } = useAppBuilderAction<ConfigData>({
+ *   name: 'getConfig',
+ *   method: 'GET',
+ * });
+ *
+ * // `loading` starts as `true`, and `response` will be populated once the action completes
+ * if (loading) {
+ *   return <Spinner />;
+ * }
+ *
+ * return <ConfigForm initialValues={response} />;
+ * ```
+ */
+export function useAppBuilderAction<T = unknown>(options: UseLazyAppBuilderActionOptions) {
+    const [loading, setLoading] = useState<boolean>(true);
+
+    const hasInvokedRef = useRef<boolean>(false);
+
+    const { response, loading: isInvoking, error, invoke } = useLazyAppBuilderAction<T>(options);
+
+    // This `useEffect` triggers `invoke` immediately on render. A use case for this is querying for a
+    // previously-set value to pre-populate the config forms as the app renders.
+    useEffect(() => {
+        if (hasInvokedRef.current) {
+            return;
+        }
+
+        invoke();
+        hasInvokedRef.current = true;
+    }, [invoke]);
+
+    // Match the loading state in this hook with the `useLazyAppBuilderAction` loading state, after the action completes.
+    useEffect(() => {
+        if (!hasInvokedRef.current) {
+            return;
+        }
+
+        setLoading(isInvoking);
+    }, [isInvoking]);
+
+    return { response, loading, error };
+}

--- a/src/web/src/hooks/useAppBuilderAction.ts
+++ b/src/web/src/hooks/useAppBuilderAction.ts
@@ -2,64 +2,151 @@ import { useCallback, useState } from 'react';
 
 import ActionRegistry from '@/config.json';
 
-export interface UseAppBuilderActionOptions {
-    name: keyof typeof ActionRegistry;
-    method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
-    searchParams?: Record<string, string>;
-    body?: object;
-    headers?: Record<string, string>;
-    ims?: { token?: string; org?: string };
-}
-
+/**
+ * Payload options that can be passed when invoking an action.
+ * These values merge with and override the options set during hook initialization.
+ */
 export interface ActionPayload {
+    /**
+     * URL search parameters to append to the action URL
+     */
     searchParams?: Record<string, string>;
+
+    /**
+     * Request body for non-GET/HEAD requests
+     */
     body?: object;
+
+    /**
+     * Custom headers to include in the request
+     */
     headers?: Record<string, string>;
 }
 
+/**
+ * Configuration options for the useAppBuilderAction hook.
+ *
+ * {@link ActionPayload}'s `searchParams`, `body`, and `headers` can be set here as default values, but can also be
+ * passed in when calling `invoke()` if we want to override the default values.
+ */
+export type UseAppBuilderActionOptions = ActionPayload & {
+    /**
+     * The name of the action to invoke. This must be a key from the action registry in `@/web/config.json`.
+     */
+    name: keyof typeof ActionRegistry;
+
+    /**
+     * HTTP method to use for the request.
+     * @default 'GET'
+     */
+    method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+
+    /**
+     * Adobe IMS authentication credentials
+     */
+    ims?: {
+        /**
+         * IMS bearer token for authorization
+         */
+        token?: string;
+
+        /**
+         * IMS organization ID
+         */
+        org?: string;
+    };
+};
+
+/**
+ * A React hook for invoking App Builder actions with built-in state management.
+ *
+ * This hook provides a convenient way to call registered App Builder actions with automatic handling of loading states,
+ * errors, and response data. It supports Adobe IMS authentication and allows configuration at both initialization and
+ * invocation time.
+ *
+ * @example
+ * ```tsx
+ * // Basic usage
+ * const { response, loading, error, invoke } = useAppBuilderAction<MyDataType>({
+ *   name: 'myAction',
+ *   method: 'GET',
+ * });
+ *
+ * // Invoke the action
+ * await invoke();
+ *
+ * // With runtime parameters
+ * await invoke({
+ *   searchParams: { id: '123' },
+ *   body: { data: 'value' },
+ * });
+ * ```
+ *
+ * @example
+ * ```tsx
+ * // With IMS authentication
+ * const { invoke } = useAppBuilderAction({
+ *   name: 'protectedAction',
+ *   method: 'POST',
+ *   ims: {
+ *     token: imsToken,
+ *     org: imsOrg,
+ *   },
+ * });
+ * ```
+ */
 export function useAppBuilderAction<T = unknown>(options: UseAppBuilderActionOptions) {
     const [response, setResponse] = useState<T | null>(null);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
 
+    /**
+     * Invokes the configured App Builder action. Optional {@link ActionPayload} can be passed in to override the
+     * default values that were set when initialising the `useAppBuilderAction` hook.
+     */
     const invoke = useCallback(
         async (invokeOptions?: ActionPayload) => {
             setLoading(true);
             setError(null);
             setResponse(null);
+
             try {
+                // Build headers with content-type, IMS auth, and custom headers
+                // Priority: content-type < IMS headers < initial headers < invoke headers
                 const headers = new Headers({
                     'content-type': 'application/json',
-                    // If provided, set the default authentication headers
-                    // They can still be overriden by custom headers when setting up
-                    // or invoking the hook
                     ...(options.ims?.org && { 'x-gw-ims-org-id': options.ims.org }),
                     ...(options.ims?.token && { Authorization: `Bearer ${options.ims.token}` }),
                     ...options.headers,
                     ...invokeOptions?.headers,
                 });
 
+                // Construct the URL from the action registry and merge search params
                 const url = new URL(ActionRegistry[options.name]);
                 const allSearchParams = { ...options.searchParams, ...invokeOptions?.searchParams };
                 for (const [k, v] of Object.entries(allSearchParams)) {
                     if (v != null) url.searchParams.set(k, v);
                 }
 
+                // Configure fetch options
                 const fetchOptions: RequestInit = {
                     method: options.method || 'GET',
                     headers,
                 };
 
+                // Attach body for non-GET/HEAD requests
                 if (fetchOptions.method !== 'GET' && fetchOptions.method !== 'HEAD') {
                     const body = invokeOptions?.body || options.body;
                     if (body) fetchOptions.body = JSON.stringify(body);
                 }
 
+                // Execute the request
                 const response = await fetch(url.toString(), fetchOptions);
                 if (!response.ok) {
                     throw new Error(`Error: ${response.status} ${response.statusText}`);
                 }
 
+                // Parse and store the response
                 const data = await response.json();
                 setResponse(data);
             } catch (err) {

--- a/src/web/src/hooks/useAppBuilderAction.ts
+++ b/src/web/src/hooks/useAppBuilderAction.ts
@@ -1,6 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
 
-import { useLazyAppBuilderAction, type UseLazyAppBuilderActionOptions } from '@/web/hooks';
+import {
+    useLazyAppBuilderAction,
+    type UseLazyAppBuilderActionOptions,
+} from '@/web/hooks/useLazyAppBuilderAction';
 
 /**
  * A React hook for invoking App Builder actions with built-in state management. The hook invokes the action

--- a/src/web/src/hooks/useAppBuilderAction.ts
+++ b/src/web/src/hooks/useAppBuilderAction.ts
@@ -71,6 +71,9 @@ export type UseAppBuilderActionOptions = ActionPayload & {
  * errors, and response data. It supports Adobe IMS authentication and allows configuration at both initialization and
  * invocation time.
  *
+ * The hook can optionally invoke the action immediately on mount by setting `shouldInvokeOnInitialisation` to `true`.
+ * This is useful for fetching initial data to pre-populate forms or display cached values when the component renders.
+ *
  * @example
  * ```tsx
  * // Basic usage
@@ -100,6 +103,23 @@ export type UseAppBuilderActionOptions = ActionPayload & {
  *     org: imsOrg,
  *   },
  * });
+ * ```
+ *
+ * @example
+ * ```tsx
+ * // Invoke immediately on mount to fetch initial data
+ * const { response, loading } = useAppBuilderAction<ConfigData>({
+ *   name: 'getConfig',
+ *   method: 'GET',
+ *   shouldInvokeOnInitialisation: true,
+ * });
+ *
+ * // `loading` starts as `true`, and `response` will be populated once the action completes
+ * if (loading) {
+ *   return <Spinner />;
+ * }
+ *
+ * return <ConfigForm initialValues={response} />;
  * ```
  */
 export function useAppBuilderAction<T = unknown>(options: UseAppBuilderActionOptions) {

--- a/src/web/src/hooks/useAppBuilderAction.ts
+++ b/src/web/src/hooks/useAppBuilderAction.ts
@@ -1,9 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 
-import {
-    useLazyAppBuilderAction,
-    UseLazyAppBuilderActionOptions,
-} from '@/hooks/useLazyAppBuilderAction';
+import { useLazyAppBuilderAction, type UseLazyAppBuilderActionOptions } from '@/hooks';
 
 /**
  * A React hook for invoking App Builder actions with built-in state management. The hook invokes the action

--- a/src/web/src/hooks/useLazyAppBuilderAction.ts
+++ b/src/web/src/hooks/useLazyAppBuilderAction.ts
@@ -29,7 +29,7 @@ export interface ActionPayload {
  * {@link ActionPayload}'s `searchParams`, `body`, and `headers` can be set here as default values, but can also be
  * passed in when calling `invoke()` if we want to override the default values.
  */
-export type UseAppBuilderActionOptions = ActionPayload & {
+export type UseLazyAppBuilderActionOptions = ActionPayload & {
     /**
      * The name of the action to invoke. This must be a key from the action registry in `@/web/config.json`.
      */
@@ -122,7 +122,7 @@ export type UseAppBuilderActionOptions = ActionPayload & {
  * return <ConfigForm initialValues={response} />;
  * ```
  */
-export function useAppBuilderAction<T = unknown>(options: UseAppBuilderActionOptions) {
+export function useLazyAppBuilderAction<T = unknown>(options: UseLazyAppBuilderActionOptions) {
     const { shouldInvokeOnInitialisation = false } = options;
 
     const [response, setResponse] = useState<T | null>(null);

--- a/src/web/src/hooks/useLazyAppBuilderAction.ts
+++ b/src/web/src/hooks/useLazyAppBuilderAction.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react';
 
-import ActionRegistry from '@/config.json';
+import ActionRegistry from '@/web/config.json';
 
 /**
  * Payload options that can be passed when invoking an action.


### PR DESCRIPTION
## Issue
Currently, the `useAppBuilderAction` hook returns an `invoke()` function, which will only trigger the action when the user calls it. However, this makes it difficult to trigger actions that need to happen on render (for example, fetching previously-set data from the database to pre-populate the config fields) without complicated `useEffect` setups.

## Description of the proposed changes
* ~~Added option for `useAppBuilderAction` hook to invoke action immediately, on render.~~
  - Code review adjustments:
    - Renamed `useAppBuilderAction` hook to `useLazyAppBuilderAction`.
    - Created a new hook `useAppBuilderAction` to handle triggering actions immediately on mount.


### Other minor improvements
* Simplified `useAppBuilderAction` types,
* Added JSDoc throughout the `useAppBuilderAction` hook, along with usage examples.

## Other improvements considered
I've thought of adding a `skip` condition prop (similar to Apollo's `useQuery` `skip`), but I can't think of a use case, so I've left it out for now. The same goes with pagination. Cache is also left out because it seems like an overkill for the time being.

## Notes to reviewers
🛈 When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback
