### PR TITLE
APP-18: Upgrade `react-router` version to 7.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "cloudevents": "^9.0.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "react-router": "^7.6.0",
+        "react-router": "^7.13.0",
         "uuid": "^8.0.0"
       },
       "devDependencies": {
@@ -16219,9 +16219,9 @@
       "license": "MIT"
     },
     "node_modules/react-router": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.0.tgz",
-      "integrity": "sha512-GGufuHIVCJDbnIAXP3P9Sxzq3UUsddG3rrI3ut1q6m0FI6vxVBF3JoPQ38+W/blslLH4a5Yutp8drkEpXoddGQ==",
+      "version": "7.13.0",
+      "resolved": "https://npm.corp.aligent.consulting/react-router/-/react-router-7.13.0.tgz",
+      "integrity": "sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "cloudevents": "^9.0.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router": "^7.6.0",
+    "react-router": "^7.13.0",
     "uuid": "^8.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description of the proposed changes
* Upgraded `react-router` version from 7.6.0 to 7.13.0.
  - There's been a few security patches since 7.6.0. For more details, see the [react-router CHANGELOG.md](https://github.com/remix-run/react-router/blob/main/CHANGELOG.md).

## Testing
Briefly tested the hash router used in the examples by pulling this update into my URL rewrites app - the navigation functionality works as expected.

## Notes to reviewers
🛈 When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback
