### PR TITLE
APP-25 - Remove wskdebug 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "@aligent/ts-code-standards": "^4.2.0",
         "@babel/preset-env": "^7.26.9",
         "@babel/preset-typescript": "^7.27.0",
-        "@openwhisk/wskdebug": "^1.3.0",
         "@types/node": "^22.14.0",
         "@types/react": "^19.1.0",
         "@types/react-dom": "^19.1.2",
@@ -54,456 +53,458 @@
       }
     },
     "node_modules/@adobe/aio-lib-campaign-standard": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@adobe/aio-lib-campaign-standard/-/aio-lib-campaign-standard-4.0.1.tgz",
-      "integrity": "sha512-UrZVOtQtANdcJoOl5BGihNl/YjcpIsj8uXk+/Wd/wdHvO1pF3DSPH2BKo2c0syfq2A9rTF5mRr8CTvBUZzFrBQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@adobe/aio-lib-campaign-standard/-/aio-lib-campaign-standard-4.0.2.tgz",
+      "integrity": "sha512-SdmNhRh+boPeNT5gwuMc5DNsfW7SGQ6/KUOc7FLvLpr8qUBrOtjEbdtHiq36TVlBwxXpSa/TK3xt6nd9Hyfzvw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/aio-lib-core-errors": "^4",
         "@adobe/aio-lib-core-logging": "^3",
         "@adobe/aio-lib-core-networking": "^5",
-        "swagger-client": "3.20.0"
+        "swagger-client": "3.34.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
-    "node_modules/@adobe/aio-lib-campaign-standard/node_modules/@swagger-api/apidom-ast": {
-      "version": "0.99.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ast/-/apidom-ast-0.99.2.tgz",
-      "integrity": "sha512-poNlXWAU2XBl192+lo5sC6loB3qGvwK30V1pta6Hs200KeTayVsMMRL4R6wDDYEtsbv7M3vQaFKcRGbYUk/SgA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-error": "^0.99.0",
-        "@types/ramda": "~0.29.6",
-        "ramda": "~0.30.0",
-        "ramda-adjunct": "^5.0.0",
-        "unraw": "^3.0.0"
-      }
-    },
     "node_modules/@adobe/aio-lib-campaign-standard/node_modules/@swagger-api/apidom-core": {
-      "version": "0.99.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-0.99.2.tgz",
-      "integrity": "sha512-deudG9eCxqgPnZyIcZzpmDxF0cja0hdPFS2hB0Op6aB4TKc9mOP1+1iEIDI3Tlx/nzgIayyAl1bblyhK3yH5fQ==",
+      "version": "1.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-1.0.0-beta.51.tgz",
+      "integrity": "sha512-vDtp1bUWm91S3Pn2Ry2ksZOfZPDiOQIhdkpB/Q0Jy6cRJCIz/IPiLWTfUaypmPCRcxcnyOXEUCSPWd+jKHKRMw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-ast": "^0.99.2",
-        "@swagger-api/apidom-error": "^0.99.0",
-        "@types/ramda": "~0.29.6",
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-ast": "^1.0.0-beta.51",
+        "@swagger-api/apidom-error": "^1.0.0-beta.51",
+        "@types/ramda": "~0.30.0",
         "minim": "~0.23.8",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
-        "short-unique-id": "^5.0.2",
-        "stampit": "^4.3.2"
+        "short-unique-id": "^5.3.2",
+        "ts-mixer": "^6.0.3"
       }
     },
     "node_modules/@adobe/aio-lib-campaign-standard/node_modules/@swagger-api/apidom-error": {
-      "version": "0.99.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-error/-/apidom-error-0.99.0.tgz",
-      "integrity": "sha512-ZdFdn+GeIo23X2GKFrfH4Y5KY8yTzVF1l/Mqjs8+nD30LTbYg6f3ITHn429dk8fDT3NT69fG+gGm60FAFaKkeQ==",
+      "version": "1.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-error/-/apidom-error-1.0.0-beta.51.tgz",
+      "integrity": "sha512-8Q1ghVuN83si6v6y/hiUYAXCDsSQEiWYHyyD1IzlDBb/f+lGu78nqaBC3cduvv/rMS1nLv8gvhMd2Gs//eDAhg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7"
       }
     },
     "node_modules/@adobe/aio-lib-campaign-standard/node_modules/@swagger-api/apidom-json-pointer": {
-      "version": "0.99.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-0.99.2.tgz",
-      "integrity": "sha512-bZENmE3H2si1yP38VLUAdhoMWNxkh98+/dCOESaw3R5zXHG04di3ShbYsCG0StkigF+eCfCdaj6XoikQOGSkiA==",
+      "version": "1.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-1.0.0-beta.51.tgz",
+      "integrity": "sha512-GiVTAFr5GwmJY+80w2E9cMuQikPm3bvrlab/6m01N1mR9m/w/kmVD+3CQKAvPN5mIzapLgHZxOLiz2upf0cemw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.99.2",
-        "@swagger-api/apidom-error": "^0.99.0",
-        "@types/ramda": "~0.29.6",
-        "ramda": "~0.30.0",
-        "ramda-adjunct": "^5.0.0"
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.0.0-beta.51",
+        "@swagger-api/apidom-error": "^1.0.0-beta.51",
+        "@swaggerexpert/json-pointer": "^2.10.1"
       }
     },
-    "node_modules/@adobe/aio-lib-campaign-standard/node_modules/@swagger-api/apidom-ns-api-design-systems": {
-      "version": "0.99.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-api-design-systems/-/apidom-ns-api-design-systems-0.99.2.tgz",
-      "integrity": "sha512-854ioZ/FB5DNiJcMinD9/a6dj6h/poOsKcb4POhPTzMSM0fHLIQUp//Ufhx7qL6qsepwtLapkgZ3/hAYN7lnBg==",
+    "node_modules/@adobe/aio-lib-campaign-standard/node_modules/@swagger-api/apidom-ns-arazzo-1": {
+      "version": "1.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-arazzo-1/-/apidom-ns-arazzo-1-1.0.0-beta.51.tgz",
+      "integrity": "sha512-AM80F1f6ii/is6GOCd7RGpeTPoxA1dwy8YCLzAUJqCeEJqtCo3cjuoBqkxNRhipt/0+euauxdHyItiGGlybiBw==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.99.2",
-        "@swagger-api/apidom-error": "^0.99.0",
-        "@swagger-api/apidom-ns-openapi-3-1": "^0.99.2",
-        "@types/ramda": "~0.29.6",
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.0.0-beta.51",
+        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.0.0-beta.51",
+        "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
         "ts-mixer": "^6.0.3"
       }
     },
     "node_modules/@adobe/aio-lib-campaign-standard/node_modules/@swagger-api/apidom-ns-asyncapi-2": {
-      "version": "0.99.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-0.99.2.tgz",
-      "integrity": "sha512-HF38kCszKYQqhQ6VMEMqd5r7gPGBRpHwPcoYaRJSDeOST/qLLG78xpoCJKQEyL3PQprea0gXKz1LG1uslDHgtQ==",
+      "version": "1.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-1.0.0-beta.51.tgz",
+      "integrity": "sha512-iSkd1NaTG3Dd5cmFpZPirjc3xev66Rx30/G3ETyb2k/kuJQqpYpVv8ctCAZmRsaaY175jqk6OwQd06EyAvPgMg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.99.2",
-        "@swagger-api/apidom-ns-json-schema-draft-7": "^0.99.2",
-        "@types/ramda": "~0.29.6",
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.0.0-beta.51",
+        "@swagger-api/apidom-ns-json-schema-draft-7": "^1.0.0-beta.51",
+        "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
         "ts-mixer": "^6.0.3"
       }
     },
-    "node_modules/@adobe/aio-lib-campaign-standard/node_modules/@swagger-api/apidom-ns-json-schema-draft-4": {
-      "version": "0.99.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-0.99.2.tgz",
-      "integrity": "sha512-vgCRaqDLI/SmTECZeKO47RGFFx6MCpOcbSm60sV0/ZJxeK+TgkNjIRJTyuRQNts44K863CWgY+bwzzn1zhNqUg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-ast": "^0.99.2",
-        "@swagger-api/apidom-core": "^0.99.2",
-        "@types/ramda": "~0.29.6",
-        "ramda": "~0.30.0",
-        "ramda-adjunct": "^5.0.0",
-        "ts-mixer": "^6.0.4"
-      }
-    },
-    "node_modules/@adobe/aio-lib-campaign-standard/node_modules/@swagger-api/apidom-ns-json-schema-draft-6": {
-      "version": "0.99.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-0.99.2.tgz",
-      "integrity": "sha512-ayKGsd65a6p/k4s5L2el+vMoMi8kc/bLXVszWszFDET1eZNvhKwEMLylGzKMfnwAFgpj+kJOKn4MZsD6PK6U/A==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.99.2",
-        "@swagger-api/apidom-error": "^0.99.0",
-        "@swagger-api/apidom-ns-json-schema-draft-4": "^0.99.2",
-        "@types/ramda": "~0.29.6",
-        "ramda": "~0.30.0",
-        "ramda-adjunct": "^5.0.0",
-        "ts-mixer": "^6.0.4"
-      }
-    },
-    "node_modules/@adobe/aio-lib-campaign-standard/node_modules/@swagger-api/apidom-ns-json-schema-draft-7": {
-      "version": "0.99.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-0.99.2.tgz",
-      "integrity": "sha512-Rn2YeQKxj6hSijQAzGRRxMYDRIedqHjE69z9xigVbvm+iDXxLJIwasuzFa7BIMRDZF5eAJkBPHXTiU9cXVsl6w==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.99.2",
-        "@swagger-api/apidom-error": "^0.99.0",
-        "@swagger-api/apidom-ns-json-schema-draft-6": "^0.99.2",
-        "@types/ramda": "~0.29.6",
-        "ramda": "~0.30.0",
-        "ramda-adjunct": "^5.0.0",
-        "ts-mixer": "^6.0.4"
-      }
-    },
     "node_modules/@adobe/aio-lib-campaign-standard/node_modules/@swagger-api/apidom-ns-openapi-2": {
-      "version": "0.99.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-2/-/apidom-ns-openapi-2-0.99.2.tgz",
-      "integrity": "sha512-4YlBvMkxSJIWrOQmsHiVuQ2VkbcWgUnOm7uiRq+8d88ur9mKI5XbP5iUvxCASuONmCqlaSU2+qoM1qesy73XPw==",
+      "version": "1.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-2/-/apidom-ns-openapi-2-1.0.0-beta.51.tgz",
+      "integrity": "sha512-Pv2rPjywIhs0kl8nkWhy5UXbqthHihcXVdNdVJF1aHDBt5VVh49VIWvM+8ngDeCad/xTPQYjeyiURX986kv/ww==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.99.2",
-        "@swagger-api/apidom-error": "^0.99.0",
-        "@swagger-api/apidom-ns-json-schema-draft-4": "^0.99.2",
-        "@types/ramda": "~0.29.6",
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.0.0-beta.51",
+        "@swagger-api/apidom-error": "^1.0.0-beta.51",
+        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.0.0-beta.51",
+        "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
         "ts-mixer": "^6.0.3"
       }
     },
     "node_modules/@adobe/aio-lib-campaign-standard/node_modules/@swagger-api/apidom-ns-openapi-3-0": {
-      "version": "0.99.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-0.99.2.tgz",
-      "integrity": "sha512-fcT597Ty3kqTkoBr1jeZ3Lfbu0a+CKd1l2ojY6RBF/5+dWNux+CRZ9qosax2XZbN+nJhSdvGLLvGvuKaV3Ybug==",
+      "version": "1.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-1.0.0-beta.51.tgz",
+      "integrity": "sha512-noFmJAQEdrS+Dm662PiJ0fzxzylz/2WzY3ZHdhbs+pVk6RY8pQsfZMIaWSzs6OTZ7BTKzxW1DvTauFRbtPxIeA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.99.2",
-        "@swagger-api/apidom-error": "^0.99.0",
-        "@swagger-api/apidom-ns-json-schema-draft-4": "^0.99.2",
-        "@types/ramda": "~0.29.6",
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.0.0-beta.51",
+        "@swagger-api/apidom-error": "^1.0.0-beta.51",
+        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.0.0-beta.51",
+        "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
         "ts-mixer": "^6.0.3"
       }
     },
     "node_modules/@adobe/aio-lib-campaign-standard/node_modules/@swagger-api/apidom-ns-openapi-3-1": {
-      "version": "0.99.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-0.99.2.tgz",
-      "integrity": "sha512-ubO8vi1dYpIV2a3IKhTkBCf125udoCeUZIc9wrhOFwwHHIKeInGR5L6yxlNhOQm0/doYCth77vEqcuTBpxaIrw==",
+      "version": "1.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-1.0.0-beta.51.tgz",
+      "integrity": "sha512-CKFZxo8sNd4SPwEmn5z+WzUBPENPMznQ64PDws/CAdJo++YwXuzeI+A6Ut1WPtB3A6n30cmYBBcasZQyuHFe8Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-ast": "^0.99.2",
-        "@swagger-api/apidom-core": "^0.99.2",
-        "@swagger-api/apidom-ns-openapi-3-0": "^0.99.2",
-        "@types/ramda": "~0.29.6",
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-ast": "^1.0.0-beta.51",
+        "@swagger-api/apidom-core": "^1.0.0-beta.51",
+        "@swagger-api/apidom-json-pointer": "^1.0.0-beta.51",
+        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.0.0-beta.51",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.0.0-beta.51",
+        "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
         "ts-mixer": "^6.0.3"
       }
     },
     "node_modules/@adobe/aio-lib-campaign-standard/node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-json": {
-      "version": "0.99.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-0.99.2.tgz",
-      "integrity": "sha512-7WPbiUJEWggVmxsssFfW/8JGk8Yu4C9ELneh805kMsgl/DOm6hcHxqT5gXXSwamH0ZQlTmSnHl2OZSlG+U5KKQ==",
+      "version": "1.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-1.0.0-beta.51.tgz",
+      "integrity": "sha512-5MkROexCuCNGUc1ymznFIIO0F54HAx7mkoJs/0fpYaQWVyjgQT6OKI9ft76Vl8cmGOKA6D7Jp0j8aoVdrjayIw==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.99.2",
-        "@swagger-api/apidom-ns-api-design-systems": "^0.99.2",
-        "@swagger-api/apidom-parser-adapter-json": "^0.99.2",
-        "@types/ramda": "~0.29.6",
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.0.0-beta.51",
+        "@swagger-api/apidom-ns-api-design-systems": "^1.0.0-beta.51",
+        "@swagger-api/apidom-parser-adapter-json": "^1.0.0-beta.51",
+        "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@adobe/aio-lib-campaign-standard/node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-yaml": {
-      "version": "0.99.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-0.99.2.tgz",
-      "integrity": "sha512-ezOA1fjBAQPQ5X0DGYnuFyZMBSBCsaT6k9KDRr7B37Do9yj8YKa/lTlg5usXOrcLm4VgcyJGTKhAJi9kfzCKcA==",
+      "version": "1.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-1.0.0-beta.51.tgz",
+      "integrity": "sha512-9drxT6AZzO2HQcGu97x1xAN8VdS6YPZL9K9Hr5fz8RkAR8SBUNblfUm796YNjJESN+Jk4DAiVoGdeI0cf6dsUA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.99.2",
-        "@swagger-api/apidom-ns-api-design-systems": "^0.99.2",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.99.2",
-        "@types/ramda": "~0.29.6",
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.0.0-beta.51",
+        "@swagger-api/apidom-ns-api-design-systems": "^1.0.0-beta.51",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-beta.51",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
+      }
+    },
+    "node_modules/@adobe/aio-lib-campaign-standard/node_modules/@swagger-api/apidom-parser-adapter-arazzo-json-1": {
+      "version": "1.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-json-1/-/apidom-parser-adapter-arazzo-json-1-1.0.0-beta.51.tgz",
+      "integrity": "sha512-EEDBI3Z4xWzhsIpFUW94n9H0cuF4lKFczhauKe5ORG2MFwaJ16MNtpnoYvpY5Ad5YZmEEn8QqaBCAgQIi8qsGA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.0.0-beta.51",
+        "@swagger-api/apidom-ns-arazzo-1": "^1.0.0-beta.51",
+        "@swagger-api/apidom-parser-adapter-json": "^1.0.0-beta.51",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
+      }
+    },
+    "node_modules/@adobe/aio-lib-campaign-standard/node_modules/@swagger-api/apidom-parser-adapter-arazzo-yaml-1": {
+      "version": "1.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-yaml-1/-/apidom-parser-adapter-arazzo-yaml-1-1.0.0-beta.51.tgz",
+      "integrity": "sha512-kUMyMf6KjDIvcfw1ukekVBf/21NA6b1ZmVEtqZK5Kmr8bnUTzrxXdXAksBGuIVhWXduuQsE8kvWigUOoMiFD3A==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.0.0-beta.51",
+        "@swagger-api/apidom-ns-arazzo-1": "^1.0.0-beta.51",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-beta.51",
+        "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@adobe/aio-lib-campaign-standard/node_modules/@swagger-api/apidom-parser-adapter-asyncapi-json-2": {
-      "version": "0.99.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-0.99.2.tgz",
-      "integrity": "sha512-b1ncaIc4dD0FGqty3iRCDUA/uHdd7nH271C06blQ+S9Id4D/xXxzd84z8LeNIJNLhCcnueuMKgUkGzvXP+raAA==",
+      "version": "1.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-1.0.0-beta.51.tgz",
+      "integrity": "sha512-bDRE4a67V/GyuKov/ox9nEEhZxKd6kwf+VQxatzm75b+U9PPb2l+105r5mJbi7nGHETt46GCT/ahZcs737wgEw==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.99.2",
-        "@swagger-api/apidom-ns-asyncapi-2": "^0.99.2",
-        "@swagger-api/apidom-parser-adapter-json": "^0.99.2",
-        "@types/ramda": "~0.29.6",
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.0.0-beta.51",
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.0.0-beta.51",
+        "@swagger-api/apidom-parser-adapter-json": "^1.0.0-beta.51",
+        "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@adobe/aio-lib-campaign-standard/node_modules/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": {
-      "version": "0.99.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-0.99.2.tgz",
-      "integrity": "sha512-NuwuwdORyZPhEpxwyEgslyGfVnwIuyDvF5TDT0cLCMOIFDqbE/n77c4FAh/nQUARDEXRthiDb5pdMo/+rOxjFg==",
+      "version": "1.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-1.0.0-beta.51.tgz",
+      "integrity": "sha512-eDZfzv+1lPWZWAk6zaDk8u8FmbvHD4i3WL3AVm5tNG8MkWAEcVzdaXiVb/GMsdmyeZ3qSIG9MPgKCdCUFkjfNw==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.99.2",
-        "@swagger-api/apidom-ns-asyncapi-2": "^0.99.2",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.99.2",
-        "@types/ramda": "~0.29.6",
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.0.0-beta.51",
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.0.0-beta.51",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-beta.51",
+        "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@adobe/aio-lib-campaign-standard/node_modules/@swagger-api/apidom-parser-adapter-json": {
-      "version": "0.99.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-0.99.2.tgz",
-      "integrity": "sha512-wy2WF71bLX1wEJkgmPRCEnXicV155KCelPQhCtzAGGo/B3+OuhknovBWXZNStvoJqZ/2A4a5pvYrgHoVoIKchg==",
+      "version": "1.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-1.0.0-beta.51.tgz",
+      "integrity": "sha512-dkVx3YBoGdbTXtMEdu3i7eQ7R3yYCf9uEGsF2iDQgx7lq5HBmr+JAbWgKbf4hYQRGtSHvm+tpGgkzBPSZAqoRg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-ast": "^0.99.2",
-        "@swagger-api/apidom-core": "^0.99.2",
-        "@swagger-api/apidom-error": "^0.99.0",
-        "@types/ramda": "~0.29.6",
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-ast": "^1.0.0-beta.51",
+        "@swagger-api/apidom-core": "^1.0.0-beta.51",
+        "@swagger-api/apidom-error": "^1.0.0-beta.51",
+        "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
-        "tree-sitter": "=0.20.4",
-        "tree-sitter-json": "=0.20.2",
-        "web-tree-sitter": "=0.20.3"
+        "tree-sitter": "=0.21.1",
+        "tree-sitter-json": "=0.24.8",
+        "web-tree-sitter": "=0.24.5"
       }
     },
     "node_modules/@adobe/aio-lib-campaign-standard/node_modules/@swagger-api/apidom-parser-adapter-openapi-json-2": {
-      "version": "0.99.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-2/-/apidom-parser-adapter-openapi-json-2-0.99.2.tgz",
-      "integrity": "sha512-z+ATszNWaO2JlixM9h4QpTAW2fE5nPCY4IDcScuWbch8gtKBmv61+53nahYb7tc3W/X0mMqhc1LyTCy5QC2L/w==",
+      "version": "1.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-2/-/apidom-parser-adapter-openapi-json-2-1.0.0-beta.51.tgz",
+      "integrity": "sha512-SuNoICSgmP2ZcwRgxJNez2c+iVN59OCuPlYlej4WqJP6EjXJgOwSwpNVKPc7U3XrJX1jRcSWYbI6vKRDFo6dZQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.99.2",
-        "@swagger-api/apidom-ns-openapi-2": "^0.99.2",
-        "@swagger-api/apidom-parser-adapter-json": "^0.99.2",
-        "@types/ramda": "~0.29.6",
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.0.0-beta.51",
+        "@swagger-api/apidom-ns-openapi-2": "^1.0.0-beta.51",
+        "@swagger-api/apidom-parser-adapter-json": "^1.0.0-beta.51",
+        "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@adobe/aio-lib-campaign-standard/node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-0": {
-      "version": "0.99.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-0.99.2.tgz",
-      "integrity": "sha512-78PFDsF67tWDjPCGAD9cNHage8p5Vs2+zili1AF2zch3JkJA/KxBt+5va4A8w1fYaUaXi8LnMkM8VvEIAsNaOw==",
+      "version": "1.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-1.0.0-beta.51.tgz",
+      "integrity": "sha512-VnG+7Yi/c4jOaXU0KHyKDzTpiW4fDTvWDq09i3EuEbrWIjDwFBp8RbvVL0zQu3rwiPH0rja+fZscINmHdL+eNA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.99.2",
-        "@swagger-api/apidom-ns-openapi-3-0": "^0.99.2",
-        "@swagger-api/apidom-parser-adapter-json": "^0.99.2",
-        "@types/ramda": "~0.29.6",
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.0.0-beta.51",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.0.0-beta.51",
+        "@swagger-api/apidom-parser-adapter-json": "^1.0.0-beta.51",
+        "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@adobe/aio-lib-campaign-standard/node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-1": {
-      "version": "0.99.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-0.99.2.tgz",
-      "integrity": "sha512-WQmm14C0EH0dcMzvgrGPeLkWKXyFwyunK9rrRt7xRLn8sL1Em0dC31hiVdgypo3DLrz9YW3PStpSQjEedJaWUQ==",
+      "version": "1.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-1.0.0-beta.51.tgz",
+      "integrity": "sha512-UXgdwLENW3dclCy5JJjiEznmQhtoN2kQV0YfeAYMgVvb/7flR9neq4zKWfmUjjyjsUre2WXowr52qMgQ1LDnCw==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.99.2",
-        "@swagger-api/apidom-ns-openapi-3-1": "^0.99.2",
-        "@swagger-api/apidom-parser-adapter-json": "^0.99.2",
-        "@types/ramda": "~0.29.6",
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.0.0-beta.51",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.0.0-beta.51",
+        "@swagger-api/apidom-parser-adapter-json": "^1.0.0-beta.51",
+        "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@adobe/aio-lib-campaign-standard/node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-2": {
-      "version": "0.99.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-2/-/apidom-parser-adapter-openapi-yaml-2-0.99.2.tgz",
-      "integrity": "sha512-rEoE54T8KKRxtdxXgvaYba+GX8853mwcw5nzdrrvOy2tNKqsJANPeJcrQmjVYqJX7SU0HuZPK3zBvyqMyKoNsg==",
+      "version": "1.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-2/-/apidom-parser-adapter-openapi-yaml-2-1.0.0-beta.51.tgz",
+      "integrity": "sha512-tbY48w31+X6qvEVadKIKFOGqpw+y2S7VTb5xPWBn8yQGt+KjaDj2ni+9KiAen8Ulnzuhk3f9KkIV2NJziig8Mw==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.99.2",
-        "@swagger-api/apidom-ns-openapi-2": "^0.99.2",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.99.2",
-        "@types/ramda": "~0.29.6",
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.0.0-beta.51",
+        "@swagger-api/apidom-ns-openapi-2": "^1.0.0-beta.51",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-beta.51",
+        "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@adobe/aio-lib-campaign-standard/node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": {
-      "version": "0.99.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-0.99.2.tgz",
-      "integrity": "sha512-l7ve45cfAj+imE8flypjdo49zpfp0m29stpOO/q2fCD5/46wT3Z4Ve3aKhil8/TRFEX26VOKoYVNjpeUWzUMaw==",
+      "version": "1.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-1.0.0-beta.51.tgz",
+      "integrity": "sha512-TEk1d4XsZokhY1k8O1ueZpKo78++o9IIzmM7oI/d5tU9wQ4dxOr2n47zZx5xFWRjjz5g6q3QBzDhTe5COdSRSw==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.99.2",
-        "@swagger-api/apidom-ns-openapi-3-0": "^0.99.2",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.99.2",
-        "@types/ramda": "~0.29.6",
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.0.0-beta.51",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.0.0-beta.51",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-beta.51",
+        "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@adobe/aio-lib-campaign-standard/node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": {
-      "version": "0.99.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-0.99.2.tgz",
-      "integrity": "sha512-1ab06o/M6MAJ0Js4C1bifpj/R0T0mw26Qk4dR7qKzel9dDuEkIRMQF7JHnf2pojZE+aR59Eb4iAMKmxzokHZdA==",
+      "version": "1.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-1.0.0-beta.51.tgz",
+      "integrity": "sha512-rg5QMNHwdXSJWRQl6Xk61YWu7Echt50zRkvARvEwBE7h0EdDpjdjBMs3ZQwTPjMgtrEuUyNwOKFrAhdpAGvQEA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.99.2",
-        "@swagger-api/apidom-ns-openapi-3-1": "^0.99.2",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.99.2",
-        "@types/ramda": "~0.29.6",
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.0.0-beta.51",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.0.0-beta.51",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-beta.51",
+        "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@adobe/aio-lib-campaign-standard/node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2": {
-      "version": "0.99.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-0.99.2.tgz",
-      "integrity": "sha512-eU6Rd58WzzcOYOajwp9UCURhXVO8SUCrau14W6BuF1DbJCr85FmOigy4yu2b9UWsK44ZPzH8KeyhSYwTkqkgLA==",
+      "version": "1.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-1.0.0-beta.51.tgz",
+      "integrity": "sha512-mURkw1jK7rVjfyjmcT3nMjl6tZlI2rdIabX4h7PpytM95Rhl885Djy1ee+p1GExVnHNo3G8RtVZLYqHC2AXZNQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-ast": "^0.99.2",
-        "@swagger-api/apidom-core": "^0.99.2",
-        "@swagger-api/apidom-error": "^0.99.0",
-        "@types/ramda": "~0.29.6",
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-ast": "^1.0.0-beta.51",
+        "@swagger-api/apidom-core": "^1.0.0-beta.51",
+        "@swagger-api/apidom-error": "^1.0.0-beta.51",
+        "@tree-sitter-grammars/tree-sitter-yaml": "=0.7.1",
+        "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
-        "tree-sitter": "=0.20.4",
-        "tree-sitter-yaml": "=0.5.0",
-        "web-tree-sitter": "=0.20.3"
+        "tree-sitter": "=0.22.4",
+        "web-tree-sitter": "=0.24.5"
+      }
+    },
+    "node_modules/@adobe/aio-lib-campaign-standard/node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2/node_modules/@tree-sitter-grammars/tree-sitter-yaml": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@tree-sitter-grammars/tree-sitter-yaml/-/tree-sitter-yaml-0.7.1.tgz",
+      "integrity": "sha512-AynBwkIoQCTgjDR33bDUp9Mqq+YTco0is3n5hRApMqG9of/6A4eQsfC1/uSEeHSUyMQSYawcAWamsexnVpIP4Q==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^8.3.1",
+        "node-gyp-build": "^4.8.4"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.22.4"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@adobe/aio-lib-campaign-standard/node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2/node_modules/tree-sitter": {
+      "version": "0.22.4",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.22.4.tgz",
+      "integrity": "sha512-usbHZP9/oxNsUY65MQUsduGRqDHQOou1cagUSwjhoSYAmSahjQDAVsh9s+SlZkn8X8+O1FULRGwHu7AFP3kjzg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
       }
     },
     "node_modules/@adobe/aio-lib-campaign-standard/node_modules/@swagger-api/apidom-reference": {
-      "version": "0.99.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-0.99.2.tgz",
-      "integrity": "sha512-QwAnCCEUbicPAVPWYOOpSI8rcj2e7TTybn1chGfdogV+NMLprGXBk/A86hO9CaSLMXkCA2rERUznSNSZWC996g==",
+      "version": "1.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-1.0.0-beta.51.tgz",
+      "integrity": "sha512-JjK5VXyIZtp4teIDIFcwIOmuBOQNc7CpD0wjIruMkNkOEzAWL4Mt+OZ9F2tZaOsNUQjWERM1NDCmb3PfuznVew==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.99.2",
-        "@types/ramda": "~0.29.6",
-        "axios": "^1.4.0",
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.0.0-beta.51",
+        "@swagger-api/apidom-error": "^1.0.0-beta.51",
+        "@types/ramda": "~0.30.0",
+        "axios": "^1.12.2",
         "minimatch": "^7.4.3",
         "process": "^0.11.10",
         "ramda": "~0.30.0",
-        "ramda-adjunct": "^5.0.0",
-        "stampit": "^4.3.2"
+        "ramda-adjunct": "^5.0.0"
       },
       "optionalDependencies": {
-        "@swagger-api/apidom-error": "^0.99.0",
-        "@swagger-api/apidom-json-pointer": "^0.99.2",
-        "@swagger-api/apidom-ns-asyncapi-2": "^0.99.2",
-        "@swagger-api/apidom-ns-openapi-2": "^0.99.2",
-        "@swagger-api/apidom-ns-openapi-3-0": "^0.99.2",
-        "@swagger-api/apidom-ns-openapi-3-1": "^0.99.2",
-        "@swagger-api/apidom-ns-workflows-1": "^0.99.2",
-        "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^0.99.2",
-        "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^0.99.2",
-        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^0.99.2",
-        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^0.99.2",
-        "@swagger-api/apidom-parser-adapter-json": "^0.99.2",
-        "@swagger-api/apidom-parser-adapter-openapi-json-2": "^0.99.2",
-        "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^0.99.2",
-        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^0.99.2",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "^0.99.2",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^0.99.2",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^0.99.2",
-        "@swagger-api/apidom-parser-adapter-workflows-json-1": "^0.99.2",
-        "@swagger-api/apidom-parser-adapter-workflows-yaml-1": "^0.99.2",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.99.2"
+        "@swagger-api/apidom-json-pointer": "^1.0.0-beta.40 <1.0.0-rc.0",
+        "@swagger-api/apidom-ns-arazzo-1": "^1.0.0-beta.40 <1.0.0-rc.0",
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.0.0-beta.40 <1.0.0-rc.0",
+        "@swagger-api/apidom-ns-openapi-2": "^1.0.0-beta.40 <1.0.0-rc.0",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.0.0-beta.40 <1.0.0-rc.0",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.0.0-beta.40 <1.0.0-rc.0",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^1.0.0-beta.40 <1.0.0-rc.0",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^1.0.0-beta.40 <1.0.0-rc.0",
+        "@swagger-api/apidom-parser-adapter-arazzo-json-1": "^1.0.0-beta.40 <1.0.0-rc.0",
+        "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": "^1.0.0-beta.40 <1.0.0-rc.0",
+        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^1.0.0-beta.40 <1.0.0-rc.0",
+        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^1.0.0-beta.40 <1.0.0-rc.0",
+        "@swagger-api/apidom-parser-adapter-json": "^1.0.0-beta.40 <1.0.0-rc.0",
+        "@swagger-api/apidom-parser-adapter-openapi-json-2": "^1.0.0-beta.40 <1.0.0-rc.0",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^1.0.0-beta.40 <1.0.0-rc.0",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^1.0.0-beta.40 <1.0.0-rc.0",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "^1.0.0-beta.40 <1.0.0-rc.0",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^1.0.0-beta.40 <1.0.0-rc.0",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^1.0.0-beta.40 <1.0.0-rc.0",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-beta.40 <1.0.0-rc.0"
       }
     },
-    "node_modules/@adobe/aio-lib-campaign-standard/node_modules/@types/ramda": {
-      "version": "0.29.12",
-      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.29.12.tgz",
-      "integrity": "sha512-sgIEjpJhdQPB52gDF4aphs9nl0xe54CR22DPdWqT8gQHjZYmVApgA0R3/CpMbl0Y8az2TEZrPNL2zy0EvjbkLA==",
-      "license": "MIT",
+    "node_modules/@adobe/aio-lib-campaign-standard/node_modules/@swaggerexpert/cookie": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@swaggerexpert/cookie/-/cookie-1.4.1.tgz",
+      "integrity": "sha512-ZRbRC2017wMs+uZeIOC55ghwgbTxeolo+s6I0njzqina7MTrOhz8WMfTj0KGk3hfBUO/yhTQD/aQZ0lQHEIKxQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "types-ramda": "^0.29.10"
+        "apg-lite": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/@adobe/aio-lib-campaign-standard/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -525,68 +526,30 @@
       }
     },
     "node_modules/@adobe/aio-lib-campaign-standard/node_modules/swagger-client": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.20.0.tgz",
-      "integrity": "sha512-5RLge2NIE1UppIT/AjUPEceT05hcBAzjiQkrXJYjpxsbFV/UDH3pp+fsrWbAeuZtgRdhNB9KDo+szLoUpzkydQ==",
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.34.0.tgz",
+      "integrity": "sha512-DQyg74J1XjpzmoOrSX0/x8OP7feeEzLTQ4ILe15TJ7oTXeC6XKQvnc5z59H5rW7vFxe+rkMlbzLCg/ri0w7Rag==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.13",
-        "@swagger-api/apidom-core": ">=0.74.1 <1.0.0",
-        "@swagger-api/apidom-json-pointer": ">=0.74.1 <1.0.0",
-        "@swagger-api/apidom-ns-openapi-3-1": ">=0.74.1 <1.0.0",
-        "@swagger-api/apidom-reference": ">=0.74.1 <1.0.0",
-        "cookie": "~0.5.0",
-        "cross-fetch": "^3.1.5",
+        "@babel/runtime-corejs3": "^7.22.15",
+        "@scarf/scarf": "=1.4.0",
+        "@swagger-api/apidom-core": ">=1.0.0-beta.11 <1.0.0-rc.0",
+        "@swagger-api/apidom-error": ">=1.0.0-beta.11 <1.0.0-rc.0",
+        "@swagger-api/apidom-json-pointer": ">=1.0.0-beta.11 <1.0.0-rc.0",
+        "@swagger-api/apidom-ns-openapi-3-1": ">=1.0.0-beta.11 <1.0.0-rc.0",
+        "@swagger-api/apidom-reference": ">=1.0.0-beta.11 <1.0.0-rc.0",
+        "@swaggerexpert/cookie": "^1.4.1",
         "deepmerge": "~4.3.0",
         "fast-json-patch": "^3.0.0-1",
-        "form-data-encoder": "^1.4.3",
-        "formdata-node": "^4.0.0",
-        "is-plain-object": "^5.0.0",
         "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "qs": "^6.10.2",
-        "traverse": "~0.6.6",
-        "url": "~0.11.0"
+        "neotraverse": "=0.6.18",
+        "node-abort-controller": "^3.1.1",
+        "node-fetch-commonjs": "^3.3.2",
+        "openapi-path-templating": "^2.0.1",
+        "openapi-server-url-templating": "^1.2.0",
+        "ramda": "^0.30.1",
+        "ramda-adjunct": "^5.0.0"
       }
-    },
-    "node_modules/@adobe/aio-lib-campaign-standard/node_modules/tree-sitter": {
-      "version": "0.20.4",
-      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.20.4.tgz",
-      "integrity": "sha512-rjfR5dc4knG3jnJNN/giJ9WOoN1zL/kZyrS0ILh+eqq8RNcIbiXA63JsMEgluug0aNvfQvK4BfCErN1vIzvKog==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "nan": "^2.17.0",
-        "prebuild-install": "^7.1.1"
-      }
-    },
-    "node_modules/@adobe/aio-lib-campaign-standard/node_modules/tree-sitter-json": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/tree-sitter-json/-/tree-sitter-json-0.20.2.tgz",
-      "integrity": "sha512-eUxrowp4F1QEGk/i7Sa+Xl8Crlfp7J0AXxX1QdJEQKQYMWhgMbCIgyQvpO3Q0P9oyTrNQxRLlRipDS44a8EtRw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "nan": "^2.18.0"
-      }
-    },
-    "node_modules/@adobe/aio-lib-campaign-standard/node_modules/types-ramda": {
-      "version": "0.29.10",
-      "resolved": "https://registry.npmjs.org/types-ramda/-/types-ramda-0.29.10.tgz",
-      "integrity": "sha512-5PJiW/eiTPyXXBYGZOYGezMl6qj7keBiZheRwfjJZY26QPHsNrjfJnz0mru6oeqqoTHOni893Jfd6zyUXfQRWg==",
-      "license": "MIT",
-      "dependencies": {
-        "ts-toolbelt": "^9.6.0"
-      }
-    },
-    "node_modules/@adobe/aio-lib-campaign-standard/node_modules/web-tree-sitter": {
-      "version": "0.20.3",
-      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.20.3.tgz",
-      "integrity": "sha512-zKGJW9r23y3BcJusbgvnOH2OYAW40MXAOi9bi3Gcc7T4Gms9WWgXF8m6adsJWpGJEhgOzCrfiz1IzKowJWrtYw==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/@adobe/aio-lib-core-config": {
       "version": "5.0.1",
@@ -3097,13 +3060,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@balena/dockerignore": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@balena/dockerignore/-/dockerignore-1.0.2.tgz",
-      "integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==",
-      "dev": true,
-      "license": "Apache-2.0"
     },
     "node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",
@@ -6323,101 +6279,6 @@
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
-      }
-    },
-    "node_modules/@openwhisk/wskdebug": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@openwhisk/wskdebug/-/wskdebug-1.4.0.tgz",
-      "integrity": "sha512-55zfVswdxH5xuVyuyVFZLUoqCT/m8wDcl5oQgJE5wClfGvP/FgqcbPIVQ8h3aYJrWcmz6LGQIkpOUw9vSsjqPA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "clone": "^2.1.2",
-        "debug": "^4.1.1",
-        "dockerode": "^3.2.0",
-        "dotenv": "^8.2.0",
-        "fetch-retry": "^3.1.0",
-        "fs-extra": "^8.1.0",
-        "get-port": "^5.1.1",
-        "is-port-reachable": "^3.0.0",
-        "livereload": "^0.9.1",
-        "manakin": "^0.5.2",
-        "node-fetch": "^2.6.7",
-        "openwhisk": "^3.21.4",
-        "ora": "^4.0.3",
-        "pretty-bytes": "^5.3.0",
-        "pretty-ms": "^6.0.1",
-        "yargs": "^15.3.1"
-      },
-      "bin": {
-        "wskdebug": "wskdebug.js"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "ngrok": "^3.2.7"
-      },
-      "peerDependenciesMeta": {
-        "ngrok": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@openwhisk/wskdebug/node_modules/dotenv": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@openwhisk/wskdebug/node_modules/fetch-retry": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-3.2.3.tgz",
-      "integrity": "sha512-baMBEv4uZ1X1cUZAvnM+C9XI7tl4CgHgJE0KBHo3JzuXO7atOeWD5HSkDA2oLYpbzLTZNslFckLkIn6T96hlew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es6-promise": "^4.2.8"
-      }
-    },
-    "node_modules/@openwhisk/wskdebug/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/@openwhisk/wskdebug/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dev": true,
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@openwhisk/wskdebug/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
       }
     },
     "node_modules/@pkgr/core": {
@@ -9892,13 +9753,13 @@
       }
     },
     "node_modules/@swagger-api/apidom-ast": {
-      "version": "1.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ast/-/apidom-ast-1.0.0-beta.30.tgz",
-      "integrity": "sha512-5Wj3zdt0dxS9ERVk4qSuqDIsMQ8dP2vop8b494OpJ/O2W261yCV39Z+vN+PqeJ2NiKDRMlJ+QoQ1uVfKwEo8Kg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ast/-/apidom-ast-1.4.0.tgz",
+      "integrity": "sha512-vaN7kA/okd3dWn45BRdsPHgGfMQdjL3TqRcxTmb41q6SLRJezINTE5nyJ8qVmH9bverOTAfn5IjYziwhV0lh7A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-error": "^1.0.0-beta.30",
+        "@swagger-api/apidom-error": "^1.4.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -9906,56 +9767,54 @@
       }
     },
     "node_modules/@swagger-api/apidom-core": {
-      "version": "1.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-1.0.0-beta.30.tgz",
-      "integrity": "sha512-pDnUhXIKKUvmeezQfwKLL05rkOH1L7ueiy5ja5ob9y2w4r+HXDID7qHtDGeRxKZoIt4E3Sd1K37OjcE9fNcknQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-1.4.0.tgz",
+      "integrity": "sha512-otHtWG8J/0bvaKThUfbSuYG9ega1jAM4ugIcxQRRozOMS7r1+pTwntbY0my5MJwZ+TeBJfVA39NRjMPiPdGttg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-ast": "^1.0.0-beta.30",
-        "@swagger-api/apidom-error": "^1.0.0-beta.30",
+        "@swagger-api/apidom-ast": "^1.4.0",
+        "@swagger-api/apidom-error": "^1.4.0",
         "@types/ramda": "~0.30.0",
         "minim": "~0.23.8",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
-        "short-unique-id": "^5.0.2",
+        "short-unique-id": "^5.3.2",
         "ts-mixer": "^6.0.3"
       }
     },
     "node_modules/@swagger-api/apidom-error": {
-      "version": "1.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-error/-/apidom-error-1.0.0-beta.30.tgz",
-      "integrity": "sha512-hVDx0kUF1DTyaEXwmsF3wpJClEfnH0pxjEubqtvHpjjeTMgZzmKc5azbYtvgBX3uUpGHyQZyG/O9g94/wIhhMA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-error/-/apidom-error-1.4.0.tgz",
+      "integrity": "sha512-oYVvGSE/y7g2mNnfNPq1IrEhhEQ0Faz1YWZWpaLF786iT0lunzzph9JG1Q9YSl+Z5yZ6XsmbKSOdvql+gK9xCw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7"
       }
     },
     "node_modules/@swagger-api/apidom-json-pointer": {
-      "version": "1.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-1.0.0-beta.30.tgz",
-      "integrity": "sha512-G+BDNXU/ARJCbJiFq1A6dh6pNDDp1J0jPfKeIHjsD8aZoRdpJC0F3F7onm8TjQm2cnvAi4B7vPOKzjWrYN1VWw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-1.4.0.tgz",
+      "integrity": "sha512-LAMOgJaKy2id2zTmMmQzSEh4HahXYfWoR6pBsdNIKaLWx6sirznFnpKHa2+shfjksAkm0Gng5/eKO1jcdySOrw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.0.0-beta.30",
-        "@swagger-api/apidom-error": "^1.0.0-beta.30",
-        "@types/ramda": "~0.30.0",
-        "ramda": "~0.30.0",
-        "ramda-adjunct": "^5.0.0"
+        "@swagger-api/apidom-core": "^1.4.0",
+        "@swagger-api/apidom-error": "^1.4.0",
+        "@swaggerexpert/json-pointer": "^2.10.1"
       }
     },
     "node_modules/@swagger-api/apidom-ns-api-design-systems": {
-      "version": "1.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-api-design-systems/-/apidom-ns-api-design-systems-1.0.0-beta.30.tgz",
-      "integrity": "sha512-YsFtttsq39qVU2J9lMD3i+aeuiMD8EjeageszDEePYgb4/k2PZX9YJqb9urwxydBM7BFG7H/r9K/dVUMHFV5hw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-api-design-systems/-/apidom-ns-api-design-systems-1.4.0.tgz",
+      "integrity": "sha512-uRTqvqSUdQwkiNlO9QMPcpI5ZF7PbwnavFwIkupbkZDb5r+kSdgu4bepXY9BjzvVeiOWqyvviIfTeccVcVOCeA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.0.0-beta.30",
-        "@swagger-api/apidom-error": "^1.0.0-beta.30",
-        "@swagger-api/apidom-ns-openapi-3-1": "^1.0.0-beta.30",
+        "@swagger-api/apidom-core": "^1.4.0",
+        "@swagger-api/apidom-error": "^1.4.0",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.4.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -9963,15 +9822,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-arazzo-1": {
-      "version": "1.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-arazzo-1/-/apidom-ns-arazzo-1-1.0.0-beta.30.tgz",
-      "integrity": "sha512-HpszcpuDlSOXWruHzasR64L8640VHVDuy8xXJrhx1iBu+gDHriOM8gbh8jQgWST91H0smtPeTG9WV1/h6frhRw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-arazzo-1/-/apidom-ns-arazzo-1-1.4.0.tgz",
+      "integrity": "sha512-gUWldcU8cCN4zYfpGdgK+rXFkcmNCv/g9eXOvQaAzYHp+N8mccRl5E0weEDRVvn9kUOA0bew7NjEEZhMulblWQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.0.0-beta.30",
-        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.0.0-beta.30",
+        "@swagger-api/apidom-core": "^1.4.0",
+        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.4.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -9979,15 +9838,31 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-asyncapi-2": {
-      "version": "1.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-1.0.0-beta.30.tgz",
-      "integrity": "sha512-/DvnCZY2cVz8E79Nc5mXD8J0++D8QT/c1PKPMMGEGVwGWB6XLh8jZM0HERb6yAiLUC0qzv4Jau/iQH1gs/ZtiQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-1.4.0.tgz",
+      "integrity": "sha512-QCzE1Dio18x/1oyElrMzwCOjnpQxlWErhcd4EIJCC61cblkHQC7feuhuZHVhH7dYqBehNH3lvJC/rBnUz8Fmlg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.0.0-beta.30",
-        "@swagger-api/apidom-ns-json-schema-draft-7": "^1.0.0-beta.30",
+        "@swagger-api/apidom-core": "^1.4.0",
+        "@swagger-api/apidom-ns-json-schema-draft-7": "^1.4.0",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0",
+        "ts-mixer": "^6.0.3"
+      }
+    },
+    "node_modules/@swagger-api/apidom-ns-asyncapi-3": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-3/-/apidom-ns-asyncapi-3-1.4.0.tgz",
+      "integrity": "sha512-XcPsuGVKO8ed8WDvA56UAUR6b8YgsL+JB/pQrSnUm2KRajg6+736c8L83a2EZB0ulaZOY2+Ex/bkuYNak0ceJA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.4.0",
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.4.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -9995,15 +9870,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-2019-09": {
-      "version": "1.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2019-09/-/apidom-ns-json-schema-2019-09-1.0.0-beta.30.tgz",
-      "integrity": "sha512-HZL76SJaUDmL1GuFcev23UX1vVuxSHIED3vvKso+k3KWNfVWZJrr7GX1ELJx84fWW8g3b5S5+nyz5q1ApT084A==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2019-09/-/apidom-ns-json-schema-2019-09-1.4.0.tgz",
+      "integrity": "sha512-xvsYdcfk00vcDYAK+qA2PBQs/uyuYUc3Bubv19s8rRd+gykdzm+7vZjYEMXIZuqn4ao+DDe7kIFipx31Cz4zTw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.0.0-beta.30",
-        "@swagger-api/apidom-error": "^1.0.0-beta.30",
-        "@swagger-api/apidom-ns-json-schema-draft-7": "^1.0.0-beta.30",
+        "@swagger-api/apidom-core": "^1.4.0",
+        "@swagger-api/apidom-error": "^1.4.0",
+        "@swagger-api/apidom-ns-json-schema-draft-7": "^1.4.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -10011,15 +9886,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-2020-12": {
-      "version": "1.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2020-12/-/apidom-ns-json-schema-2020-12-1.0.0-beta.30.tgz",
-      "integrity": "sha512-D2adAcu/ISoBe0zRbcX0HyaDvWoMhmaL8iPR4pvjLY7soB2tCR4uLEzAkqPa2zaOKBRA2ziF74aNKrKbM5sX8w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2020-12/-/apidom-ns-json-schema-2020-12-1.4.0.tgz",
+      "integrity": "sha512-FOadSRcNmKmXDi71DpOaNyXIvIY13FSFzCVLoMrIJfAVMmuuWN+hgBjedjnp8mkRjzTW96XRjAuCQ1WUT2OCFA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.0.0-beta.30",
-        "@swagger-api/apidom-error": "^1.0.0-beta.30",
-        "@swagger-api/apidom-ns-json-schema-2019-09": "^1.0.0-beta.30",
+        "@swagger-api/apidom-core": "^1.4.0",
+        "@swagger-api/apidom-error": "^1.4.0",
+        "@swagger-api/apidom-ns-json-schema-2019-09": "^1.4.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -10027,14 +9902,14 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-draft-4": {
-      "version": "1.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-1.0.0-beta.30.tgz",
-      "integrity": "sha512-u5YMIw/g74Z59wPBFS2A2LaheC+EEqRcbpUQOApTvb6zjW+xWxbCuKV1ypzIaVDDPIry8e3mpwjjXLj1mvad5w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-1.4.0.tgz",
+      "integrity": "sha512-LKzAUqHEAgm4WmuYbhPCDycr1nO/G14NwNG35RQJHVZi+FRrvzFgD80h5yNNzYjXYtNQrRGtKPTR6LXImZjWag==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-ast": "^1.0.0-beta.30",
-        "@swagger-api/apidom-core": "^1.0.0-beta.30",
+        "@swagger-api/apidom-ast": "^1.4.0",
+        "@swagger-api/apidom-core": "^1.4.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -10042,15 +9917,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-draft-6": {
-      "version": "1.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-1.0.0-beta.30.tgz",
-      "integrity": "sha512-/Mp11+tBKTN6XnpOiQo/cKnqmvfJhdCniHCK6Bg8wpCI3dMi+nSSpIYgWEPVQfNsLtf/PaYegrtYY56W4UzNRw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-1.4.0.tgz",
+      "integrity": "sha512-QoxxQw0xDpFe2SYeX96Gt2rp1MSQcvSoiiV9yR6G9j0Jbr3bipFiI6rK4OFSXq3Wcalfccjz77aiG42K9QDWUQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.0.0-beta.30",
-        "@swagger-api/apidom-error": "^1.0.0-beta.30",
-        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.0.0-beta.30",
+        "@swagger-api/apidom-core": "^1.4.0",
+        "@swagger-api/apidom-error": "^1.4.0",
+        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.4.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -10058,15 +9933,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-draft-7": {
-      "version": "1.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-1.0.0-beta.30.tgz",
-      "integrity": "sha512-6sZ0LLYnEz9KXtt9xTRSc0EORBl5Fj3LUbfabUjqLQZGldsJWU+3TTQ4XtzFFHlan7z2WYyALKP7iP+b60XbPg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-1.4.0.tgz",
+      "integrity": "sha512-jnjuj4n26FhS2ZXwA6n86PlRi2sZ5GIP18JBRLGwDxTRCEqguX7Ar1NgKDn9VCoCmSZQ04ebLoipFGafvlA3VA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.0.0-beta.30",
-        "@swagger-api/apidom-error": "^1.0.0-beta.30",
-        "@swagger-api/apidom-ns-json-schema-draft-6": "^1.0.0-beta.30",
+        "@swagger-api/apidom-core": "^1.4.0",
+        "@swagger-api/apidom-error": "^1.4.0",
+        "@swagger-api/apidom-ns-json-schema-draft-6": "^1.4.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -10074,16 +9949,16 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-openapi-2": {
-      "version": "1.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-2/-/apidom-ns-openapi-2-1.0.0-beta.30.tgz",
-      "integrity": "sha512-nloJUjf6AtKRnBuWmaFkVk7lR7aht9cudXkR/W0ui+feLSJ5rnYy6nyLyGFLZqLnb2cSV8L6bB6tGPJnvc5KzA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-2/-/apidom-ns-openapi-2-1.4.0.tgz",
+      "integrity": "sha512-2Uxy+dv4oU5Zw03Twkoxz1FWz4117Sz6UEWUmRaFsijGpaxWkauy6tBpp/U43D86eMRpkR6Jb6OA+UTaENYxxQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.0.0-beta.30",
-        "@swagger-api/apidom-error": "^1.0.0-beta.30",
-        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.0.0-beta.30",
+        "@swagger-api/apidom-core": "^1.4.0",
+        "@swagger-api/apidom-error": "^1.4.0",
+        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.4.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -10091,15 +9966,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-openapi-3-0": {
-      "version": "1.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-1.0.0-beta.30.tgz",
-      "integrity": "sha512-7bz6kCgjStTKGGI4wBP2ho574lyfjH5EDPPuXhkwmAG2mOn9MZezlQhsbdo3B+vbi/58mqQb2XCoB4aeP1F+GQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-1.4.0.tgz",
+      "integrity": "sha512-012Zx/r6ncajjc98AzZNDUpt1ShXwutUtrvCuBoz8dwQzpJfPc2HNGMM6tOvYX/isqzeCG7+zlKEG8tEv0X1RA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.0.0-beta.30",
-        "@swagger-api/apidom-error": "^1.0.0-beta.30",
-        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.0.0-beta.30",
+        "@swagger-api/apidom-core": "^1.4.0",
+        "@swagger-api/apidom-error": "^1.4.0",
+        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.4.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -10107,652 +9982,310 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-openapi-3-1": {
-      "version": "1.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-1.0.0-beta.30.tgz",
-      "integrity": "sha512-pq2jxSp0I6xnGzyAiEXWYMuurp8H7TlOQ6Ijr/XX54gNmaIK+yQ3HXc7S6FZx+B2kQx03Tb8Y8O7L7J7YnmFiA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-1.4.0.tgz",
+      "integrity": "sha512-ZW91r56RyalrNdxB4vnJNOXLNi/iQZSyvUjNDkJAO5e8/z3Hf7evU1ftCpgvsQVwiVXOG+b5KfgOw3Lwbc+a2w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-ast": "^1.0.0-beta.30",
-        "@swagger-api/apidom-core": "^1.0.0-beta.30",
-        "@swagger-api/apidom-json-pointer": "^1.0.0-beta.30",
-        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.0.0-beta.30",
-        "@swagger-api/apidom-ns-openapi-3-0": "^1.0.0-beta.30",
+        "@swagger-api/apidom-ast": "^1.4.0",
+        "@swagger-api/apidom-core": "^1.4.0",
+        "@swagger-api/apidom-json-pointer": "^1.4.0",
+        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.4.0",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.4.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
         "ts-mixer": "^6.0.3"
       }
     },
-    "node_modules/@swagger-api/apidom-ns-workflows-1": {
-      "version": "0.99.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-workflows-1/-/apidom-ns-workflows-1-0.99.2.tgz",
-      "integrity": "sha512-lm8G7cbCRXukN4UOb/bPszUiSbvN1ymvwQ2PEkyZN+DzJvYfgRuAxXt7xd2EDKJcxeH4igpAnkKoIoBoSOHg+w==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.99.2",
-        "@swagger-api/apidom-ns-openapi-3-1": "^0.99.2",
-        "@types/ramda": "~0.29.6",
-        "ramda": "~0.30.0",
-        "ramda-adjunct": "^5.0.0",
-        "ts-mixer": "^6.0.3"
-      }
-    },
-    "node_modules/@swagger-api/apidom-ns-workflows-1/node_modules/@swagger-api/apidom-ast": {
-      "version": "0.99.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ast/-/apidom-ast-0.99.2.tgz",
-      "integrity": "sha512-poNlXWAU2XBl192+lo5sC6loB3qGvwK30V1pta6Hs200KeTayVsMMRL4R6wDDYEtsbv7M3vQaFKcRGbYUk/SgA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-error": "^0.99.0",
-        "@types/ramda": "~0.29.6",
-        "ramda": "~0.30.0",
-        "ramda-adjunct": "^5.0.0",
-        "unraw": "^3.0.0"
-      }
-    },
-    "node_modules/@swagger-api/apidom-ns-workflows-1/node_modules/@swagger-api/apidom-core": {
-      "version": "0.99.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-0.99.2.tgz",
-      "integrity": "sha512-deudG9eCxqgPnZyIcZzpmDxF0cja0hdPFS2hB0Op6aB4TKc9mOP1+1iEIDI3Tlx/nzgIayyAl1bblyhK3yH5fQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-ast": "^0.99.2",
-        "@swagger-api/apidom-error": "^0.99.0",
-        "@types/ramda": "~0.29.6",
-        "minim": "~0.23.8",
-        "ramda": "~0.30.0",
-        "ramda-adjunct": "^5.0.0",
-        "short-unique-id": "^5.0.2",
-        "stampit": "^4.3.2"
-      }
-    },
-    "node_modules/@swagger-api/apidom-ns-workflows-1/node_modules/@swagger-api/apidom-error": {
-      "version": "0.99.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-error/-/apidom-error-0.99.0.tgz",
-      "integrity": "sha512-ZdFdn+GeIo23X2GKFrfH4Y5KY8yTzVF1l/Mqjs8+nD30LTbYg6f3ITHn429dk8fDT3NT69fG+gGm60FAFaKkeQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.7"
-      }
-    },
-    "node_modules/@swagger-api/apidom-ns-workflows-1/node_modules/@swagger-api/apidom-ns-json-schema-draft-4": {
-      "version": "0.99.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-0.99.2.tgz",
-      "integrity": "sha512-vgCRaqDLI/SmTECZeKO47RGFFx6MCpOcbSm60sV0/ZJxeK+TgkNjIRJTyuRQNts44K863CWgY+bwzzn1zhNqUg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-ast": "^0.99.2",
-        "@swagger-api/apidom-core": "^0.99.2",
-        "@types/ramda": "~0.29.6",
-        "ramda": "~0.30.0",
-        "ramda-adjunct": "^5.0.0",
-        "ts-mixer": "^6.0.4"
-      }
-    },
-    "node_modules/@swagger-api/apidom-ns-workflows-1/node_modules/@swagger-api/apidom-ns-openapi-3-0": {
-      "version": "0.99.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-0.99.2.tgz",
-      "integrity": "sha512-fcT597Ty3kqTkoBr1jeZ3Lfbu0a+CKd1l2ojY6RBF/5+dWNux+CRZ9qosax2XZbN+nJhSdvGLLvGvuKaV3Ybug==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.99.2",
-        "@swagger-api/apidom-error": "^0.99.0",
-        "@swagger-api/apidom-ns-json-schema-draft-4": "^0.99.2",
-        "@types/ramda": "~0.29.6",
-        "ramda": "~0.30.0",
-        "ramda-adjunct": "^5.0.0",
-        "ts-mixer": "^6.0.3"
-      }
-    },
-    "node_modules/@swagger-api/apidom-ns-workflows-1/node_modules/@swagger-api/apidom-ns-openapi-3-1": {
-      "version": "0.99.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-0.99.2.tgz",
-      "integrity": "sha512-ubO8vi1dYpIV2a3IKhTkBCf125udoCeUZIc9wrhOFwwHHIKeInGR5L6yxlNhOQm0/doYCth77vEqcuTBpxaIrw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-ast": "^0.99.2",
-        "@swagger-api/apidom-core": "^0.99.2",
-        "@swagger-api/apidom-ns-openapi-3-0": "^0.99.2",
-        "@types/ramda": "~0.29.6",
-        "ramda": "~0.30.0",
-        "ramda-adjunct": "^5.0.0",
-        "ts-mixer": "^6.0.3"
-      }
-    },
-    "node_modules/@swagger-api/apidom-ns-workflows-1/node_modules/@types/ramda": {
-      "version": "0.29.12",
-      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.29.12.tgz",
-      "integrity": "sha512-sgIEjpJhdQPB52gDF4aphs9nl0xe54CR22DPdWqT8gQHjZYmVApgA0R3/CpMbl0Y8az2TEZrPNL2zy0EvjbkLA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "types-ramda": "^0.29.10"
-      }
-    },
-    "node_modules/@swagger-api/apidom-ns-workflows-1/node_modules/types-ramda": {
-      "version": "0.29.10",
-      "resolved": "https://registry.npmjs.org/types-ramda/-/types-ramda-0.29.10.tgz",
-      "integrity": "sha512-5PJiW/eiTPyXXBYGZOYGezMl6qj7keBiZheRwfjJZY26QPHsNrjfJnz0mru6oeqqoTHOni893Jfd6zyUXfQRWg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ts-toolbelt": "^9.6.0"
-      }
-    },
     "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-json": {
-      "version": "1.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-1.0.0-beta.30.tgz",
-      "integrity": "sha512-ER5kQtxOXG8W1cQC7xH8EYYUOAMaqVrECIZShoa6yOLoI0/a40xFF5Lansn2P9szR1hT/2neM8KLcjaxCFjXSQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-1.4.0.tgz",
+      "integrity": "sha512-XtLjh4dHQZwLkqhYSA2Uizu33/MrJsnk2KYXujokMJN4BkfGa6thzzvjTUCC7ZFQW6hV2aMm6tmwm51UdWCCMQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.0.0-beta.30",
-        "@swagger-api/apidom-ns-api-design-systems": "^1.0.0-beta.30",
-        "@swagger-api/apidom-parser-adapter-json": "^1.0.0-beta.30",
+        "@swagger-api/apidom-core": "^1.4.0",
+        "@swagger-api/apidom-ns-api-design-systems": "^1.4.0",
+        "@swagger-api/apidom-parser-adapter-json": "^1.4.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-yaml": {
-      "version": "1.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-1.0.0-beta.30.tgz",
-      "integrity": "sha512-Xghcidv1TJVwrb/jFHQZA5YHPm+LxNPpFjOJYrijugXK72D3a5fqc/2PZzkGXeYefE4lGM+YB83c08N6NDCa4w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-1.4.0.tgz",
+      "integrity": "sha512-1adlUHS7X1FAFVFb/3XnLh/D8PLcbBcf40OXmIpdQW92fIUdhhUJfuthTD6i4no0bEplkFATyO6Yd6LYNAGSCw==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.0.0-beta.30",
-        "@swagger-api/apidom-ns-api-design-systems": "^1.0.0-beta.30",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-beta.30",
+        "@swagger-api/apidom-core": "^1.4.0",
+        "@swagger-api/apidom-ns-api-design-systems": "^1.4.0",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.4.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-arazzo-json-1": {
-      "version": "1.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-json-1/-/apidom-parser-adapter-arazzo-json-1-1.0.0-beta.30.tgz",
-      "integrity": "sha512-SZajkrTJ7c1I9CI3gnsdHZCQFSIyQ2H/lkWDjA/drZkRcfbR1CTbR2q0BGGlV5Y+nFHBxjRNpPbYbZrqh0WV4w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-json-1/-/apidom-parser-adapter-arazzo-json-1-1.4.0.tgz",
+      "integrity": "sha512-Xqzi8ciYxNaMIXLtWh/80xQAh6ulqd/yOxDXJKdQqAQSExGwRI3bXHo0ynIvMJIkO049VKDhvqmTv1vEmZwQUA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.0.0-beta.30",
-        "@swagger-api/apidom-ns-arazzo-1": "^1.0.0-beta.30",
-        "@swagger-api/apidom-parser-adapter-json": "^1.0.0-beta.30",
+        "@swagger-api/apidom-core": "^1.4.0",
+        "@swagger-api/apidom-ns-arazzo-1": "^1.4.0",
+        "@swagger-api/apidom-parser-adapter-json": "^1.4.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-arazzo-yaml-1": {
-      "version": "1.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-yaml-1/-/apidom-parser-adapter-arazzo-yaml-1-1.0.0-beta.30.tgz",
-      "integrity": "sha512-T+N1ix+V5IpOWMFcamQRI50830JayD1gifnRm+mVeWJKMzp+xm08bnO8NiR9LQ2SKJZ6FWYM38oG2tAt0Lwxcg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-yaml-1/-/apidom-parser-adapter-arazzo-yaml-1-1.4.0.tgz",
+      "integrity": "sha512-HkWOuNjKnzgaa/ZCSLT1v+kqBof1dou6m3dXUfWw/hTpXk4Pp/kwKtqz9n+LCvG2bNfVEZFvwgGF3N6ZSujdog==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.0.0-beta.30",
-        "@swagger-api/apidom-ns-arazzo-1": "^1.0.0-beta.30",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-beta.30",
+        "@swagger-api/apidom-core": "^1.4.0",
+        "@swagger-api/apidom-ns-arazzo-1": "^1.4.0",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.4.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-json-2": {
-      "version": "1.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-1.0.0-beta.30.tgz",
-      "integrity": "sha512-KjyF966T9HVvSsk+RWaOcNDxXBqOWr/09SAw1OdBBfGHqs+xF3KOV7/2RB88Adw3+ZZ3E5oXDvVVhobq8wVvyA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-1.4.0.tgz",
+      "integrity": "sha512-i0WWw0xPZvPf3jTET0YzE8INu7PyNTyypD09WCKhhKgmFpNmZ2SHbHTP6+/OTTRu4nId9+icD6cHKCma0/W2tQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.0.0-beta.30",
-        "@swagger-api/apidom-ns-asyncapi-2": "^1.0.0-beta.30",
-        "@swagger-api/apidom-parser-adapter-json": "^1.0.0-beta.30",
+        "@swagger-api/apidom-core": "^1.4.0",
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.4.0",
+        "@swagger-api/apidom-parser-adapter-json": "^1.4.0",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
+      }
+    },
+    "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-json-3": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-3/-/apidom-parser-adapter-asyncapi-json-3-1.4.0.tgz",
+      "integrity": "sha512-zKklrdThBa9yqmYeZYyX5zd0NKCLIUOIkV1HtMXsCg2f9ceTHldtenn3RvqYMY0EDd6IpVRfLfOhUNPpttTLOg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.4.0",
+        "@swagger-api/apidom-ns-asyncapi-3": "^1.4.0",
+        "@swagger-api/apidom-parser-adapter-json": "^1.4.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": {
-      "version": "1.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-1.0.0-beta.30.tgz",
-      "integrity": "sha512-+6zlRD0nP7T5Yiu9hHgP3b7d016WYRXqfr9TW/yqPFInM/tI74ROPJnMQ1G3s0HyW6lB0KX7cG0O0TqcMmnSqg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-1.4.0.tgz",
+      "integrity": "sha512-+hzzfCSJ8KaoApYmI22aYKoXi0La0/696FaOnCloPloKZwcPvjR5S7WxleZTMuAcXzeM4R/92LbD5BTUein4Ow==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.0.0-beta.30",
-        "@swagger-api/apidom-ns-asyncapi-2": "^1.0.0-beta.30",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-beta.30",
+        "@swagger-api/apidom-core": "^1.4.0",
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.4.0",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.4.0",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
+      }
+    },
+    "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-3/-/apidom-parser-adapter-asyncapi-yaml-3-1.4.0.tgz",
+      "integrity": "sha512-R7cbEbFYTJ8hCV04VkaRap54T0t4Q+v9gXvxVf+Kn1csRXoR0O/yJBakCcmv7taswzv+1dCWbjJOJSHDJFIB0w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.4.0",
+        "@swagger-api/apidom-ns-asyncapi-3": "^1.4.0",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.4.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-json": {
-      "version": "1.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-1.0.0-beta.30.tgz",
-      "integrity": "sha512-cciT19OOXafwBnXe9KFVwUGEVu4Zrvb4k12TYNlNqzVg1xA9pBc3Ywq5EgHIhiiQOLY3fILr0fr6B36N6irN2Q==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-1.4.0.tgz",
+      "integrity": "sha512-QfwjuG1UaEYGf+tpPfN6GAZTJezhq2uy5Dgxmxe1f9Z/0V3mZmmdFck+NEXU698tAvFsf+qMeFmeR22EB4mzSg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-ast": "^1.0.0-beta.30",
-        "@swagger-api/apidom-core": "^1.0.0-beta.30",
-        "@swagger-api/apidom-error": "^1.0.0-beta.30",
+        "@swagger-api/apidom-ast": "^1.4.0",
+        "@swagger-api/apidom-core": "^1.4.0",
+        "@swagger-api/apidom-error": "^1.4.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
-        "tree-sitter": "=0.22.1",
+        "tree-sitter": "=0.22.4",
         "tree-sitter-json": "=0.24.8",
         "web-tree-sitter": "=0.24.5"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-json/node_modules/tree-sitter": {
-      "version": "0.22.1",
-      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.22.1.tgz",
-      "integrity": "sha512-gRO+jk2ljxZlIn20QRskIvpLCMtzuLl5T0BY6L9uvPYD17uUrxlxWkvYCiVqED2q2q7CVtY52Uex4WcYo2FEXw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "node-addon-api": "^8.2.1",
-        "node-gyp-build": "^4.8.2"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-2": {
-      "version": "1.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-2/-/apidom-parser-adapter-openapi-json-2-1.0.0-beta.30.tgz",
-      "integrity": "sha512-Q5b9XVTId/FiGSmGKSOxyKJZYdvWcZOqogpLkF0Q8PtPVCgp2LFl73XuJOgjxO1nkE+n/ap+93svgaaxQRaVow==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.0.0-beta.30",
-        "@swagger-api/apidom-ns-openapi-2": "^1.0.0-beta.30",
-        "@swagger-api/apidom-parser-adapter-json": "^1.0.0-beta.30",
-        "@types/ramda": "~0.30.0",
-        "ramda": "~0.30.0",
-        "ramda-adjunct": "^5.0.0"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-0": {
-      "version": "1.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-1.0.0-beta.30.tgz",
-      "integrity": "sha512-VsDpKXmRl6sXpgR6o582yyDJqfFfliYVrVWve0DCOTkpvOeOYqPPLA45oMMvunJkqVsBL4Fpy9/ZqAQvdlur7g==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.0.0-beta.30",
-        "@swagger-api/apidom-ns-openapi-3-0": "^1.0.0-beta.30",
-        "@swagger-api/apidom-parser-adapter-json": "^1.0.0-beta.30",
-        "@types/ramda": "~0.30.0",
-        "ramda": "~0.30.0",
-        "ramda-adjunct": "^5.0.0"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-1": {
-      "version": "1.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-1.0.0-beta.30.tgz",
-      "integrity": "sha512-Q2NQ1/IF500mFuZZDC3tTw75UOTgSknqRyBywsA159BRnqnWxwk/2//Ifh8Vwq/mMyW2zSChigCvnqI+/IvQxA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.0.0-beta.30",
-        "@swagger-api/apidom-ns-openapi-3-1": "^1.0.0-beta.30",
-        "@swagger-api/apidom-parser-adapter-json": "^1.0.0-beta.30",
-        "@types/ramda": "~0.30.0",
-        "ramda": "~0.30.0",
-        "ramda-adjunct": "^5.0.0"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-2": {
-      "version": "1.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-2/-/apidom-parser-adapter-openapi-yaml-2-1.0.0-beta.30.tgz",
-      "integrity": "sha512-6Zj1UtbQIwnsVJi2xn+Zl9yn9U014XzkX6QKrpAXIUGNCcjwWIbuOKd3u2T481OOP0BuVf3JpWhRqxumtosV3w==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.0.0-beta.30",
-        "@swagger-api/apidom-ns-openapi-2": "^1.0.0-beta.30",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-beta.30",
-        "@types/ramda": "~0.30.0",
-        "ramda": "~0.30.0",
-        "ramda-adjunct": "^5.0.0"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": {
-      "version": "1.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-1.0.0-beta.30.tgz",
-      "integrity": "sha512-YaGDkZaV9ZRtbIGorsyyqL2x323gLMqqgLrPpAjaBbBFiAJRwF/gwRHMY4iJ85H2YeUxUq0jqtSc3jH3wsQJGg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.0.0-beta.30",
-        "@swagger-api/apidom-ns-openapi-3-0": "^1.0.0-beta.30",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-beta.30",
-        "@types/ramda": "~0.30.0",
-        "ramda": "~0.30.0",
-        "ramda-adjunct": "^5.0.0"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": {
-      "version": "1.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-1.0.0-beta.30.tgz",
-      "integrity": "sha512-rBa7daaUrDVAIwJZm+S4lwc5pqNt6avNTGxEB69dNZ3QDJmCC+HUnudUtsG3VqMfP46JITKUPvtzRLGjX8CgRg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.0.0-beta.30",
-        "@swagger-api/apidom-ns-openapi-3-1": "^1.0.0-beta.30",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-beta.30",
-        "@types/ramda": "~0.30.0",
-        "ramda": "~0.30.0",
-        "ramda-adjunct": "^5.0.0"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-workflows-json-1": {
-      "version": "0.99.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-workflows-json-1/-/apidom-parser-adapter-workflows-json-1-0.99.2.tgz",
-      "integrity": "sha512-VsFVmwTX/OfsXyBmIEp5Y+adqBF4Cj/cM/55KPM3mIEmKbc+PK3M08TIotMk1FdCiTafe+I28OZL+WMVujNm1A==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.99.2",
-        "@swagger-api/apidom-ns-workflows-1": "^0.99.2",
-        "@swagger-api/apidom-parser-adapter-json": "^0.99.2",
-        "@types/ramda": "~0.29.6",
-        "ramda": "~0.30.0",
-        "ramda-adjunct": "^5.0.0"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-workflows-json-1/node_modules/@swagger-api/apidom-ast": {
-      "version": "0.99.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ast/-/apidom-ast-0.99.2.tgz",
-      "integrity": "sha512-poNlXWAU2XBl192+lo5sC6loB3qGvwK30V1pta6Hs200KeTayVsMMRL4R6wDDYEtsbv7M3vQaFKcRGbYUk/SgA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-error": "^0.99.0",
-        "@types/ramda": "~0.29.6",
-        "ramda": "~0.30.0",
-        "ramda-adjunct": "^5.0.0",
-        "unraw": "^3.0.0"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-workflows-json-1/node_modules/@swagger-api/apidom-core": {
-      "version": "0.99.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-0.99.2.tgz",
-      "integrity": "sha512-deudG9eCxqgPnZyIcZzpmDxF0cja0hdPFS2hB0Op6aB4TKc9mOP1+1iEIDI3Tlx/nzgIayyAl1bblyhK3yH5fQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-ast": "^0.99.2",
-        "@swagger-api/apidom-error": "^0.99.0",
-        "@types/ramda": "~0.29.6",
-        "minim": "~0.23.8",
-        "ramda": "~0.30.0",
-        "ramda-adjunct": "^5.0.0",
-        "short-unique-id": "^5.0.2",
-        "stampit": "^4.3.2"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-workflows-json-1/node_modules/@swagger-api/apidom-error": {
-      "version": "0.99.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-error/-/apidom-error-0.99.0.tgz",
-      "integrity": "sha512-ZdFdn+GeIo23X2GKFrfH4Y5KY8yTzVF1l/Mqjs8+nD30LTbYg6f3ITHn429dk8fDT3NT69fG+gGm60FAFaKkeQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.7"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-workflows-json-1/node_modules/@swagger-api/apidom-parser-adapter-json": {
-      "version": "0.99.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-0.99.2.tgz",
-      "integrity": "sha512-wy2WF71bLX1wEJkgmPRCEnXicV155KCelPQhCtzAGGo/B3+OuhknovBWXZNStvoJqZ/2A4a5pvYrgHoVoIKchg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-ast": "^0.99.2",
-        "@swagger-api/apidom-core": "^0.99.2",
-        "@swagger-api/apidom-error": "^0.99.0",
-        "@types/ramda": "~0.29.6",
-        "ramda": "~0.30.0",
-        "ramda-adjunct": "^5.0.0",
-        "tree-sitter": "=0.20.4",
-        "tree-sitter-json": "=0.20.2",
-        "web-tree-sitter": "=0.20.3"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-workflows-json-1/node_modules/@types/ramda": {
-      "version": "0.29.12",
-      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.29.12.tgz",
-      "integrity": "sha512-sgIEjpJhdQPB52gDF4aphs9nl0xe54CR22DPdWqT8gQHjZYmVApgA0R3/CpMbl0Y8az2TEZrPNL2zy0EvjbkLA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "types-ramda": "^0.29.10"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-workflows-json-1/node_modules/tree-sitter": {
-      "version": "0.20.4",
-      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.20.4.tgz",
-      "integrity": "sha512-rjfR5dc4knG3jnJNN/giJ9WOoN1zL/kZyrS0ILh+eqq8RNcIbiXA63JsMEgluug0aNvfQvK4BfCErN1vIzvKog==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "nan": "^2.17.0",
-        "prebuild-install": "^7.1.1"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-workflows-json-1/node_modules/tree-sitter-json": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/tree-sitter-json/-/tree-sitter-json-0.20.2.tgz",
-      "integrity": "sha512-eUxrowp4F1QEGk/i7Sa+Xl8Crlfp7J0AXxX1QdJEQKQYMWhgMbCIgyQvpO3Q0P9oyTrNQxRLlRipDS44a8EtRw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "nan": "^2.18.0"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-workflows-json-1/node_modules/types-ramda": {
-      "version": "0.29.10",
-      "resolved": "https://registry.npmjs.org/types-ramda/-/types-ramda-0.29.10.tgz",
-      "integrity": "sha512-5PJiW/eiTPyXXBYGZOYGezMl6qj7keBiZheRwfjJZY26QPHsNrjfJnz0mru6oeqqoTHOni893Jfd6zyUXfQRWg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ts-toolbelt": "^9.6.0"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-workflows-json-1/node_modules/web-tree-sitter": {
-      "version": "0.20.3",
-      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.20.3.tgz",
-      "integrity": "sha512-zKGJW9r23y3BcJusbgvnOH2OYAW40MXAOi9bi3Gcc7T4Gms9WWgXF8m6adsJWpGJEhgOzCrfiz1IzKowJWrtYw==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-workflows-yaml-1": {
-      "version": "0.99.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-workflows-yaml-1/-/apidom-parser-adapter-workflows-yaml-1-0.99.2.tgz",
-      "integrity": "sha512-yK+48YcllFc8mY711ZJ7uTfPVZmJdujIHbvGLOMxMODmETkZlEjfoTAwNTWvutcuA6cxK70tKUD8vz5572ALQA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.99.2",
-        "@swagger-api/apidom-ns-workflows-1": "^0.99.2",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.99.2",
-        "@types/ramda": "~0.29.6",
-        "ramda": "~0.30.0",
-        "ramda-adjunct": "^5.0.0"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-workflows-yaml-1/node_modules/@swagger-api/apidom-ast": {
-      "version": "0.99.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ast/-/apidom-ast-0.99.2.tgz",
-      "integrity": "sha512-poNlXWAU2XBl192+lo5sC6loB3qGvwK30V1pta6Hs200KeTayVsMMRL4R6wDDYEtsbv7M3vQaFKcRGbYUk/SgA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-error": "^0.99.0",
-        "@types/ramda": "~0.29.6",
-        "ramda": "~0.30.0",
-        "ramda-adjunct": "^5.0.0",
-        "unraw": "^3.0.0"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-workflows-yaml-1/node_modules/@swagger-api/apidom-core": {
-      "version": "0.99.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-0.99.2.tgz",
-      "integrity": "sha512-deudG9eCxqgPnZyIcZzpmDxF0cja0hdPFS2hB0Op6aB4TKc9mOP1+1iEIDI3Tlx/nzgIayyAl1bblyhK3yH5fQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-ast": "^0.99.2",
-        "@swagger-api/apidom-error": "^0.99.0",
-        "@types/ramda": "~0.29.6",
-        "minim": "~0.23.8",
-        "ramda": "~0.30.0",
-        "ramda-adjunct": "^5.0.0",
-        "short-unique-id": "^5.0.2",
-        "stampit": "^4.3.2"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-workflows-yaml-1/node_modules/@swagger-api/apidom-error": {
-      "version": "0.99.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-error/-/apidom-error-0.99.0.tgz",
-      "integrity": "sha512-ZdFdn+GeIo23X2GKFrfH4Y5KY8yTzVF1l/Mqjs8+nD30LTbYg6f3ITHn429dk8fDT3NT69fG+gGm60FAFaKkeQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.7"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-workflows-yaml-1/node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2": {
-      "version": "0.99.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-0.99.2.tgz",
-      "integrity": "sha512-eU6Rd58WzzcOYOajwp9UCURhXVO8SUCrau14W6BuF1DbJCr85FmOigy4yu2b9UWsK44ZPzH8KeyhSYwTkqkgLA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-ast": "^0.99.2",
-        "@swagger-api/apidom-core": "^0.99.2",
-        "@swagger-api/apidom-error": "^0.99.0",
-        "@types/ramda": "~0.29.6",
-        "ramda": "~0.30.0",
-        "ramda-adjunct": "^5.0.0",
-        "tree-sitter": "=0.20.4",
-        "tree-sitter-yaml": "=0.5.0",
-        "web-tree-sitter": "=0.20.3"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-workflows-yaml-1/node_modules/@types/ramda": {
-      "version": "0.29.12",
-      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.29.12.tgz",
-      "integrity": "sha512-sgIEjpJhdQPB52gDF4aphs9nl0xe54CR22DPdWqT8gQHjZYmVApgA0R3/CpMbl0Y8az2TEZrPNL2zy0EvjbkLA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "types-ramda": "^0.29.10"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-workflows-yaml-1/node_modules/tree-sitter": {
-      "version": "0.20.4",
-      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.20.4.tgz",
-      "integrity": "sha512-rjfR5dc4knG3jnJNN/giJ9WOoN1zL/kZyrS0ILh+eqq8RNcIbiXA63JsMEgluug0aNvfQvK4BfCErN1vIzvKog==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "nan": "^2.17.0",
-        "prebuild-install": "^7.1.1"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-workflows-yaml-1/node_modules/types-ramda": {
-      "version": "0.29.10",
-      "resolved": "https://registry.npmjs.org/types-ramda/-/types-ramda-0.29.10.tgz",
-      "integrity": "sha512-5PJiW/eiTPyXXBYGZOYGezMl6qj7keBiZheRwfjJZY26QPHsNrjfJnz0mru6oeqqoTHOni893Jfd6zyUXfQRWg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ts-toolbelt": "^9.6.0"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-workflows-yaml-1/node_modules/web-tree-sitter": {
-      "version": "0.20.3",
-      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.20.3.tgz",
-      "integrity": "sha512-zKGJW9r23y3BcJusbgvnOH2OYAW40MXAOi9bi3Gcc7T4Gms9WWgXF8m6adsJWpGJEhgOzCrfiz1IzKowJWrtYw==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2": {
-      "version": "1.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-1.0.0-beta.30.tgz",
-      "integrity": "sha512-NRmQehyw4gbDzeBAl0zjyPqj4e/jNYgqnRLcOsxTKpWODud8RHBqEvju/M6iET6ru0o+A9265efFzqR9hiE0LA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-ast": "^1.0.0-beta.30",
-        "@swagger-api/apidom-core": "^1.0.0-beta.30",
-        "@swagger-api/apidom-error": "^1.0.0-beta.30",
-        "@tree-sitter-grammars/tree-sitter-yaml": "=0.7.0",
-        "@types/ramda": "~0.30.0",
-        "ramda": "~0.30.0",
-        "ramda-adjunct": "^5.0.0",
-        "tree-sitter": "=0.22.1",
-        "web-tree-sitter": "=0.24.5"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2/node_modules/@tree-sitter-grammars/tree-sitter-yaml": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@tree-sitter-grammars/tree-sitter-yaml/-/tree-sitter-yaml-0.7.0.tgz",
-      "integrity": "sha512-GOMIK3IaDvECD0eZEhAsLl03RMtM1E8StxuGMn6PpMKFg7jyQ+jSzxJZ4Jmc/tYitah9/AECt8o4tlRQ5yEZQg==",
+      "version": "0.22.4",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.22.4.tgz",
+      "integrity": "sha512-usbHZP9/oxNsUY65MQUsduGRqDHQOou1cagUSwjhoSYAmSahjQDAVsh9s+SlZkn8X8+O1FULRGwHu7AFP3kjzg==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "node-addon-api": "^8.3.0",
         "node-gyp-build": "^4.8.4"
+      }
+    },
+    "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-2": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-2/-/apidom-parser-adapter-openapi-json-2-1.4.0.tgz",
+      "integrity": "sha512-1crFQpjzGod/wdW8BE1C8j/qMe02EaUlXt8ZWePns3GzEWSEdxRuiiNh/b0EzXVlAUStcRigzaajNsn+KT3tUA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.4.0",
+        "@swagger-api/apidom-ns-openapi-2": "^1.4.0",
+        "@swagger-api/apidom-parser-adapter-json": "^1.4.0",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
+      }
+    },
+    "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-0": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-1.4.0.tgz",
+      "integrity": "sha512-K7r2qZ3wNu+ql4yUsTILbMCTZ5BY0deEi+ig+9KskRqjJ/0TZeeqq3rj8GCgHw7ocQh2WnMBeGGX1YO8bWBAUQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.4.0",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.4.0",
+        "@swagger-api/apidom-parser-adapter-json": "^1.4.0",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
+      }
+    },
+    "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-1": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-1.4.0.tgz",
+      "integrity": "sha512-oECL5TrqbYzVRv17Jco1G3KruZkh7N7iKhfqgBcb1irZ4ozXNlv1FtZ8bZxpczXxvGhSkSLFKbEd0pHZaO0iPA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.4.0",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.4.0",
+        "@swagger-api/apidom-parser-adapter-json": "^1.4.0",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
+      }
+    },
+    "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-2": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-2/-/apidom-parser-adapter-openapi-yaml-2-1.4.0.tgz",
+      "integrity": "sha512-Ai0j0oInutDAb0Lvpb/UBhatc0QOLgdYpAPupafvjCEFt6fTpomO2HjNA+4Z+0cqH69ggKgQ/ldJ5G8FgqKcrw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.4.0",
+        "@swagger-api/apidom-ns-openapi-2": "^1.4.0",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.4.0",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
+      }
+    },
+    "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-1.4.0.tgz",
+      "integrity": "sha512-DD6JwfHcywPxZl7e3UqeAU4qdzjQaVudUnnFHWH83m6qWEHldN1+vSfQTzn4DQgi9dz88XfIakUJ1HFHIfEBhg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.4.0",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.4.0",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.4.0",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
+      }
+    },
+    "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-1.4.0.tgz",
+      "integrity": "sha512-FWGMgP1iJGIXISLSyz0j/Pthux11H712gPYzaL7DRZz8wevQvgc4TrYF4hHZwSvN8xpEkJLURBclfwsLDKzIXQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.4.0",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.4.0",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.4.0",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
+      }
+    },
+    "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-1.4.0.tgz",
+      "integrity": "sha512-rqVxBEiuCyBbNhnFUsBxPEewFjKDBYkiFqJGmwNo79G51wJOK9GnSjT1AyMZ+fW3RDlDZ+HR8IojQCykhYoAGg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-ast": "^1.4.0",
+        "@swagger-api/apidom-core": "^1.4.0",
+        "@swagger-api/apidom-error": "^1.4.0",
+        "@tree-sitter-grammars/tree-sitter-yaml": "=0.7.1",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0",
+        "tree-sitter": "=0.22.4",
+        "web-tree-sitter": "=0.24.5"
+      }
+    },
+    "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2/node_modules/@tree-sitter-grammars/tree-sitter-yaml": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@tree-sitter-grammars/tree-sitter-yaml/-/tree-sitter-yaml-0.7.1.tgz",
+      "integrity": "sha512-AynBwkIoQCTgjDR33bDUp9Mqq+YTco0is3n5hRApMqG9of/6A4eQsfC1/uSEeHSUyMQSYawcAWamsexnVpIP4Q==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^8.3.1",
+        "node-gyp-build": "^4.8.4"
       },
       "peerDependencies": {
-        "tree-sitter": "^0.22.1"
+        "tree-sitter": "^0.22.4"
       },
       "peerDependenciesMeta": {
         "tree-sitter": {
@@ -10761,60 +10294,62 @@
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2/node_modules/tree-sitter": {
-      "version": "0.22.1",
-      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.22.1.tgz",
-      "integrity": "sha512-gRO+jk2ljxZlIn20QRskIvpLCMtzuLl5T0BY6L9uvPYD17uUrxlxWkvYCiVqED2q2q7CVtY52Uex4WcYo2FEXw==",
+      "version": "0.22.4",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.22.4.tgz",
+      "integrity": "sha512-usbHZP9/oxNsUY65MQUsduGRqDHQOou1cagUSwjhoSYAmSahjQDAVsh9s+SlZkn8X8+O1FULRGwHu7AFP3kjzg==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "node-addon-api": "^8.2.1",
-        "node-gyp-build": "^4.8.2"
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
       }
     },
     "node_modules/@swagger-api/apidom-reference": {
-      "version": "1.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-1.0.0-beta.30.tgz",
-      "integrity": "sha512-l1MpLMlmaX+y2hra5EadfR37sAMzmEz1wZomVcnw7vJEFlLQo3WwOdFvpQemPCZ9IJHUs+5zhZ++w7z60uKpSw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-1.4.0.tgz",
+      "integrity": "sha512-MRqShsNMzigiJxFNYWF4YyPfzVNyEAm1E4DngYENuZxV+Hf+2Zri+DEk3FL6JPoDLLx/UYO1EB9S8VuPZeNT6g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.0.0-beta.30",
+        "@swagger-api/apidom-core": "^1.4.0",
+        "@swagger-api/apidom-error": "^1.4.0",
         "@types/ramda": "~0.30.0",
-        "axios": "^1.8.2",
+        "axios": "^1.12.2",
         "minimatch": "^7.4.3",
         "process": "^0.11.10",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       },
       "optionalDependencies": {
-        "@swagger-api/apidom-error": "^1.0.0-beta.3 <1.0.0-rc.0",
-        "@swagger-api/apidom-json-pointer": "^1.0.0-beta.3 <1.0.0-rc.0",
-        "@swagger-api/apidom-ns-arazzo-1": "^1.0.0-beta.3 <1.0.0-rc.0",
-        "@swagger-api/apidom-ns-asyncapi-2": "^1.0.0-beta.3 <1.0.0-rc.0",
-        "@swagger-api/apidom-ns-openapi-2": "^1.0.0-beta.3 <1.0.0-rc.0",
-        "@swagger-api/apidom-ns-openapi-3-0": "^1.0.0-beta.3 <1.0.0-rc.0",
-        "@swagger-api/apidom-ns-openapi-3-1": "^1.0.0-beta.3 <1.0.0-rc.0",
-        "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^1.0.0-beta.3 <1.0.0-rc.0",
-        "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^1.0.0-beta.3 <1.0.0-rc.0",
-        "@swagger-api/apidom-parser-adapter-arazzo-json-1": "^1.0.0-beta.3 <1.0.0-rc.0",
-        "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": "^1.0.0-beta.3 <1.0.0-rc.0",
-        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^1.0.0-beta.3 <1.0.0-rc.0",
-        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^1.0.0-beta.3 <1.0.0-rc.0",
-        "@swagger-api/apidom-parser-adapter-json": "^1.0.0-beta.3 <1.0.0-rc.0",
-        "@swagger-api/apidom-parser-adapter-openapi-json-2": "^1.0.0-beta.3 <1.0.0-rc.0",
-        "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^1.0.0-beta.3 <1.0.0-rc.0",
-        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^1.0.0-beta.3 <1.0.0-rc.0",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "^1.0.0-beta.3 <1.0.0-rc.0",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^1.0.0-beta.3 <1.0.0-rc.0",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^1.0.0-beta.3 <1.0.0-rc.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-beta.3 <1.0.0-rc.0"
+        "@swagger-api/apidom-json-pointer": "^1.4.0",
+        "@swagger-api/apidom-ns-arazzo-1": "^1.4.0",
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.4.0",
+        "@swagger-api/apidom-ns-openapi-2": "^1.4.0",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.4.0",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.4.0",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^1.4.0",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^1.4.0",
+        "@swagger-api/apidom-parser-adapter-arazzo-json-1": "^1.4.0",
+        "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": "^1.4.0",
+        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^1.4.0",
+        "@swagger-api/apidom-parser-adapter-asyncapi-json-3": "^1.4.0",
+        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^1.4.0",
+        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": "^1.4.0",
+        "@swagger-api/apidom-parser-adapter-json": "^1.4.0",
+        "@swagger-api/apidom-parser-adapter-openapi-json-2": "^1.4.0",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^1.4.0",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^1.4.0",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "^1.4.0",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^1.4.0",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^1.4.0",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.4.0"
       }
     },
     "node_modules/@swagger-api/apidom-reference/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -10842,6 +10377,18 @@
       "license": "Apache-2.0",
       "dependencies": {
         "apg-lite": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/@swaggerexpert/json-pointer": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@swaggerexpert/json-pointer/-/json-pointer-2.10.2.tgz",
+      "integrity": "sha512-qMx1nOrzoB+PF+pzb26Q4Tc2sOlrx9Ba2UBNX9hB31Omrq+QoZ2Gly0KLrQWw4Of1AQ4J9lnD+XOdwOdcdXqqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "apg-lite": "^1.0.4"
       },
       "engines": {
         "node": ">=12.20.0"
@@ -11867,6 +11414,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
       "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -11982,6 +11530,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
       "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "array-buffer-byte-length": "^1.0.1",
@@ -11997,16 +11546,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/asn1": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
       }
     },
     "node_modules/ast-types-flow": {
@@ -12026,19 +11565,10 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
       "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/async-retry": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
-      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "retry": "0.13.1"
       }
     },
     "node_modules/asynckit": {
@@ -12274,27 +11804,6 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "devOptional": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.19",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
@@ -12303,16 +11812,6 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
-      }
-    },
-    "node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
       }
     },
     "node_modules/bignumber.js": {
@@ -12324,35 +11823,10 @@
         "node": "*"
       }
     },
-    "node_modules/binary-extensions": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
-      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12430,47 +11904,12 @@
         "node-int64": "^0.4.0"
       }
     },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "devOptional": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/buildcheck": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.6.tgz",
-      "integrity": "sha512-8f9ZJCUXyT1M35Jx7MkBgmBMo3oHTTBIPLiY9xyL0pl3T5RwcPEY8cUHr5LBNfu/fk6c2T4DJZuVM/8ZZT2D2A==",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">=10.0.0"
-      }
     },
     "node_modules/call-bind": {
       "version": "1.0.8",
@@ -12628,51 +12067,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/chokidar/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "devOptional": true,
-      "license": "ISC"
-    },
     "node_modules/chrome-trace-event": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
@@ -12707,32 +12101,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cli-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "restore-cursor": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cli-spinners": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
-      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/cli-width": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
@@ -12748,28 +12116,6 @@
       "resolved": "https://npm.corp.aligent.consulting/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
-    },
-    "node_modules/cliui": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^6.2.0"
-      }
-    },
-    "node_modules/clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
     },
     "node_modules/cloudevents": {
       "version": "9.0.0",
@@ -13037,15 +12383,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/core-js-compat": {
       "version": "3.41.0",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.41.0.tgz",
@@ -13071,21 +12408,6 @@
         "url": "https://opencollective.com/core-js"
       }
     },
-    "node_modules/cpu-features": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
-      "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "dependencies": {
-        "buildcheck": "~0.0.6",
-        "nan": "^2.19.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/create-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
@@ -13106,15 +12428,6 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/cross-fetch": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
-      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
-      "license": "MIT",
-      "dependencies": {
-        "node-fetch": "^2.7.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -13155,6 +12468,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
       "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -13172,6 +12486,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
       "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -13189,6 +12504,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
       "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -13219,37 +12535,11 @@
         }
       }
     },
-    "node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/decimal.js": {
       "version": "10.6.0",
       "resolved": "https://npm.corp.aligent.consulting/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "license": "MIT"
-    },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/dedent": {
       "version": "1.5.3",
@@ -13264,16 +12554,6 @@
         "babel-plugin-macros": {
           "optional": true
         }
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -13291,29 +12571,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/defaults": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
-      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "clone": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/defaults/node_modules/clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/define-data-property": {
@@ -13337,6 +12594,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.0.1",
@@ -13359,16 +12617,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/detect-libc": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
-      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -13387,37 +12635,6 @@
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/docker-modem": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-3.0.8.tgz",
-      "integrity": "sha512-f0ReSURdM3pcKPNS30mxOHSbaFLcknGmQjwSfmbcdOw1XWKXVhukM3NJHhr7NpY9BIyyWQb0EBo3KQvvuU5egQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "readable-stream": "^3.5.0",
-        "split-ca": "^1.0.1",
-        "ssh2": "^1.11.0"
-      },
-      "engines": {
-        "node": ">= 8.0"
-      }
-    },
-    "node_modules/dockerode": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-3.3.5.tgz",
-      "integrity": "sha512-/0YNa3ZDNeLr/tSckmD69+Gq+qVNhvKfAHNeZJBnp7EOP6RGKV8ORrJHkUn20So5wU+xxT7+1n5u8PjHbfjbSA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@balena/dockerignore": "^1.0.2",
-        "docker-modem": "^3.0.0",
-        "tar-fs": "~2.0.1"
-      },
-      "engines": {
-        "node": ">= 8.0"
       }
     },
     "node_modules/doctrine": {
@@ -13528,16 +12745,6 @@
       "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
       "license": "MIT"
     },
-    "node_modules/end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
-      }
-    },
     "node_modules/enhanced-resolve": {
       "version": "5.19.0",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.19.0.tgz",
@@ -13573,6 +12780,7 @@
       "version": "1.24.1",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
       "integrity": "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "array-buffer-byte-length": "^1.0.2",
@@ -13735,6 +12943,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
       "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.2.7",
@@ -13747,13 +12956,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -14163,16 +13365,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "license": "(MIT OR WTFPL)",
-      "optional": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/expect": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
@@ -14310,9 +13502,9 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14442,45 +13634,10 @@
         "node": ">= 6"
       }
     },
-    "node_modules/form-data-encoder": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.9.0.tgz",
-      "integrity": "sha512-rahaRMkN8P8d/tgK/BLPX+WBVM27NbvdXBxqQujBtkDAIFspaRqN7Od7lfdGQA6KAD+f82fYCLBq1ipvcu8qLw==",
-      "license": "MIT"
-    },
-    "node_modules/formdata-node": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
-      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "1.0.0",
-        "web-streams-polyfill": "4.0.0-beta.3"
-      },
-      "engines": {
-        "node": ">= 12.20"
-      }
-    },
-    "node_modules/formdata-node/node_modules/web-streams-polyfill": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
-      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/forwarded-parse": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
       "integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==",
-      "license": "MIT"
-    },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/fs-extra": {
@@ -14532,6 +13689,7 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
       "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -14552,6 +13710,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -14653,19 +13812,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/get-port": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
-      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/get-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -14696,6 +13842,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
       "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -14708,13 +13855,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -14778,6 +13918,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-properties": "^1.2.1",
@@ -14846,6 +13987,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
       "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -14880,6 +14022,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
       "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.0"
@@ -15035,40 +14178,6 @@
         "node": ">=10.17.0"
       }
     },
-    "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "devOptional": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -15164,17 +14273,11 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "license": "ISC",
-      "optional": true
-    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
       "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -15217,6 +14320,7 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
       "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -15240,6 +14344,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
       "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "async-function": "^1.0.0",
@@ -15259,6 +14364,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
       "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-bigints": "^1.0.2"
@@ -15270,23 +14376,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "binary-extensions": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-boolean-object": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
       "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -15331,6 +14425,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
       "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -15348,6 +14443,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
       "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -15366,6 +14462,7 @@
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15374,6 +14471,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
       "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3"
@@ -15428,6 +14526,7 @@
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -15435,20 +14534,11 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-interactive": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
-      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
       "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -15461,6 +14551,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
       "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -15490,6 +14581,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
       "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -15500,25 +14592,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-plain-object": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-port-reachable": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-port-reachable/-/is-port-reachable-3.1.0.tgz",
-      "integrity": "sha512-vjc0SSRNZ32s9SbZBzGaiP6YVB+xglLShhgZD/FHMZUXBvQWaV9CtzgeVhjccFJrI6RAMV+LX7NYxueW/A8W5A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-regex": {
@@ -15543,6 +14616,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
       "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -15555,6 +14629,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
       "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3"
@@ -15582,6 +14657,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
       "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -15598,6 +14674,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
       "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -15630,6 +14707,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
       "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -15642,6 +14720,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
       "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3"
@@ -15657,6 +14736,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
       "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -15673,6 +14753,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -16796,32 +15877,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/livereload": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/livereload/-/livereload-0.9.3.tgz",
-      "integrity": "sha512-q7Z71n3i4X0R9xthAryBdNGVGAO2R5X+/xXpmKeuPMrteg+W2U8VusTKV3YiJbXZwKsOlFlHe+go6uSNjfxrZw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chokidar": "^3.5.0",
-        "livereload-js": "^3.3.1",
-        "opts": ">= 1.2.0",
-        "ws": "^7.4.3"
-      },
-      "bin": {
-        "livereload": "bin/livereload.js"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/livereload-js": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-3.4.1.tgz",
-      "integrity": "sha512-5MP0uUeVCec89ZbNOT/i97Mc+q3SxXmiUGhRFOTmhrGPn//uWVQdCvcLJDy64MSBR5MidFdOR7B9viumoavy6g==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/loader-runner": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
@@ -16892,97 +15947,6 @@
       "dev": true,
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/log-symbols": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
-      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^2.4.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/log-symbols/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/log-symbols/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/log-symbols/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/log-symbols/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/log-symbols/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/log-symbols/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/log-symbols/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/logform": {
       "version": "2.7.0",
@@ -17084,17 +16048,6 @@
         "tmpl": "1.0.5"
       }
     },
-    "node_modules/manakin": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/manakin/-/manakin-0.5.2.tgz",
-      "integrity": "sha512-pfDSB7QYoVg0Io4KMV9hhPoXpj6p0uBscgtyUSKCOFZe8bqgbpStfgnKIbF/ulnr6U3ICu4OqdyxAqBgOhZwBQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12",
-        "npm": ">=1.4"
-      }
-    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -17156,19 +16109,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/minim": {
       "version": "0.23.8",
       "resolved": "https://registry.npmjs.org/minim/-/minim-0.23.8.tgz",
@@ -17193,23 +16133,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "license": "MIT",
-      "optional": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "devOptional": true,
-      "license": "MIT"
     },
     "node_modules/module-details-from-path": {
       "version": "1.0.4",
@@ -17340,50 +16263,12 @@
         "node": ">=12"
       }
     },
-    "node_modules/mute-stream": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/nan": {
-      "version": "2.22.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.2.tgz",
-      "integrity": "sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/napi-build-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/needle": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-3.3.1.tgz",
-      "integrity": "sha512-6k0YULvhpw+RoLNiQCRKOl09Rv1dPLr8hHnVjHqdolKwDrdNyk+Hmrthi4lIGPPz3r39dLx0hsF5s40sZ3Us4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "iconv-lite": "^0.6.3",
-        "sax": "^1.2.4"
-      },
-      "bin": {
-        "needle": "bin/needle"
-      },
-      "engines": {
-        "node": ">= 4.4.x"
-      }
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
@@ -17412,32 +16297,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/node-abi": {
-      "version": "3.74.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.74.0.tgz",
-      "integrity": "sha512-c5XK0MjkGBrQPGYG24GBADZud0NCbznxNx0ZkS+ebUTrmV1qTDxPxSL8zEAPURXSbLRWVexxmP4986BziahL5w==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/node-abi/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "license": "ISC",
-      "optional": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/node-abort-controller": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
@@ -17445,9 +16304,9 @@
       "license": "MIT"
     },
     "node_modules/node-addon-api": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.3.1.tgz",
-      "integrity": "sha512-lytcDEdxKjGJPTLEfW4mYMigRezMlyJY8W4wxJK8zE533Jlb8L8dRuObJFWg2P+AuOIxoCgKF+2Oq4d4Zd0OUA==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -17572,6 +16431,7 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -17584,6 +16444,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -17593,6 +16454,7 @@
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
       "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -17667,7 +16529,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -17722,20 +16584,6 @@
         "node": ">=12.20.0"
       }
     },
-    "node_modules/openwhisk": {
-      "version": "3.21.8",
-      "resolved": "https://registry.npmjs.org/openwhisk/-/openwhisk-3.21.8.tgz",
-      "integrity": "sha512-GoD4wytw7KSNSwZ4f6/iQcLPJK8cW0FRyhuaQkRbsGL6BCV9tigQ9zoQdJRkZUKilm29cLyGIAF5cn3pFn73LQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "async-retry": "^1.3.3",
-        "needle": "^3.2.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/optimism": {
       "version": "0.18.1",
       "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.18.1.tgz",
@@ -17768,50 +16616,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/opts": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/opts/-/opts-2.0.2.tgz",
-      "integrity": "sha512-k41FwbcLnlgnFh69f4qdUfvDQ+5vaSDnVPFI/y5XuhKRq97EnVVneO9F1ESVCdiVu4fCS2L8usX3mU331hB7pg==",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/ora": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-4.1.1.tgz",
-      "integrity": "sha512-sjYP8QyVWBpBZWD6Vr1M/KwknSw6kJOz41tvGMlwWeClHBtYKTbHMki1PsLZnxKpXMPbTKv9b3pjQu3REib96A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^3.0.0",
-        "cli-cursor": "^3.1.0",
-        "cli-spinners": "^2.2.0",
-        "is-interactive": "^1.0.0",
-        "log-symbols": "^3.0.0",
-        "mute-stream": "0.0.8",
-        "strip-ansi": "^6.0.0",
-        "wcwidth": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ora/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/outvariant": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
@@ -17823,6 +16627,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
       "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.2.6",
@@ -17919,16 +16724,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/parse-ms": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",
-      "integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/pascal-case": {
@@ -18173,33 +16968,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/prebuild-install": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^2.0.0",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -18337,19 +17105,6 @@
         }
       }
     },
-    "node_modules/pretty-bytes": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
-      "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/pretty-format": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
@@ -18384,22 +17139,6 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/pretty-ms": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-6.0.1.tgz",
-      "integrity": "sha512-ke4njoVmlotekHlHyCZ3wI/c5AMT8peuHs8rKJqekj/oR5G8lND2dVpicFlUz5cbZgE290vvkMuDwfj/OcW1kw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "parse-ms": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/priorityqueuejs": {
       "version": "1.0.0",
@@ -18494,23 +17233,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/pump": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
-      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
-    "node_modules/punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
-      "license": "MIT"
-    },
     "node_modules/pure-rand": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
@@ -18527,21 +17249,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/querystringify": {
       "version": "2.2.0",
@@ -18585,32 +17292,6 @@
       "peer": true,
       "dependencies": {
         "safe-buffer": "^5.1.0"
-      }
-    },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "optional": true,
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
-    "node_modules/rc/node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/react": {
@@ -18758,12 +17439,16 @@
       }
     },
     "node_modules/react-router/node_modules/cookie": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
-      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/react-stately": {
@@ -18833,23 +17518,11 @@
         "node": ">= 6"
       }
     },
-    "node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
-    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
       "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -18908,6 +17581,7 @@
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
       "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -19025,13 +17699,6 @@
         "node": ">=9.3.0 || >=8.10.0 <9.0.0"
       }
     },
-    "node_modules/require-main-filename": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -19101,30 +17768,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/restore-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/retry": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/rxjs": {
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
@@ -19138,6 +17781,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
       "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -19177,6 +17821,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
       "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -19214,13 +17859,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/sax": {
       "version": "1.4.1",
@@ -19295,13 +17933,6 @@
         "randombytes": "^2.1.0"
       }
     },
-    "node_modules/set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/set-cookie-parser": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
@@ -19329,6 +17960,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
       "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -19344,6 +17976,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
       "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -19391,9 +18024,9 @@
       }
     },
     "node_modules/short-unique-id": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/short-unique-id/-/short-unique-id-5.2.2.tgz",
-      "integrity": "sha512-MlRVyT5RYfDO2kUzBgOPlZriRzG+NIAuwSy1HBN8tahXyFi3+804GGi/mzjUsi6VxgiQuDgMnhoI2FqmSHX8Tg==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/short-unique-id/-/short-unique-id-5.3.2.tgz",
+      "integrity": "sha512-KRT/hufMSxXKEDSQujfVE0Faa/kZ51ihUcZQAcmP04t00DvPj7Ox5anHke1sJYUtzSuiT/Y5uyzg/W7bBEGhCg==",
       "license": "Apache-2.0",
       "bin": {
         "short-unique-id": "bin/short-unique-id",
@@ -19404,6 +18037,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -19423,6 +18057,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -19439,6 +18074,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -19457,6 +18093,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -19478,53 +18115,6 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
     },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
@@ -19595,37 +18185,12 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/split-ca": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
-      "integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true,
       "license": "BSD-3-Clause"
-    },
-    "node_modules/ssh2": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.16.0.tgz",
-      "integrity": "sha512-r1X4KsBGedJqo7h8F5c4Ybpcr5RjyP+aWIG007uBPRjmdQWfEiVLzSK71Zji1B9sKxwaCvD8y8cwSkYrlLiRRg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "asn1": "^0.2.6",
-        "bcrypt-pbkdf": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=10.16.0"
-      },
-      "optionalDependencies": {
-        "cpu-features": "~0.0.10",
-        "nan": "^2.20.0"
-      }
     },
     "node_modules/stack-trace": {
       "version": "0.0.10",
@@ -19659,12 +18224,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/stampit": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/stampit/-/stampit-4.3.2.tgz",
-      "integrity": "sha512-pE2org1+ZWQBnIxRPrBM2gVupkuDD0TTNIo1H6GdT/vO82NXli2z8lRE8cu/nBIHrcOCXFBAHpb9ZldrB2/qOA==",
-      "license": "MIT"
-    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -19679,6 +18238,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
       "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -19796,6 +18356,7 @@
       "version": "1.2.10",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
       "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -19817,6 +18378,7 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
       "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -19835,6 +18397,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
       "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -19932,18 +18495,18 @@
       }
     },
     "node_modules/swagger-client": {
-      "version": "3.34.4",
-      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.34.4.tgz",
-      "integrity": "sha512-Qvtu8DtARAx5GwefA0eV1WRLa4Q9bhczrtNAsiBMOx3HkxAOczy1APQhrcblJdLys0xEGQ4xYizYFXfIL9BhpA==",
+      "version": "3.36.1",
+      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.36.1.tgz",
+      "integrity": "sha512-bcYpeN4P3sOoKi22zsxIlL9lSgouBAmQmL5hH4g5yeOvyTUvq1+OFtGTs0l1C5Dkb0ZN+2vNgp0FBAFulmUklA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.22.15",
         "@scarf/scarf": "=1.4.0",
-        "@swagger-api/apidom-core": ">=1.0.0-beta.13 <1.0.0-rc.0",
-        "@swagger-api/apidom-error": ">=1.0.0-beta.13 <1.0.0-rc.0",
-        "@swagger-api/apidom-json-pointer": ">=1.0.0-beta.13 <1.0.0-rc.0",
-        "@swagger-api/apidom-ns-openapi-3-1": ">=1.0.0-beta.13 <1.0.0-rc.0",
-        "@swagger-api/apidom-reference": ">=1.0.0-beta.13 <1.0.0-rc.0",
+        "@swagger-api/apidom-core": "^1.3.0",
+        "@swagger-api/apidom-error": "^1.3.0",
+        "@swagger-api/apidom-json-pointer": "^1.3.0",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.3.0",
+        "@swagger-api/apidom-reference": "^1.3.0",
         "@swaggerexpert/cookie": "^2.0.2",
         "deepmerge": "~4.3.0",
         "fast-json-patch": "^3.0.0-1",
@@ -19995,36 +18558,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/tar-fs": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.1.tgz",
-      "integrity": "sha512-6tzWDMeroL87uF/+lin46k+Q+46rAJ0SyPGz7OW7wTgblI273hsBqk2C1j0/xNadNLKDTUL9BukSjB7cwgmlPA==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.0.0"
-      }
-    },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/terser": {
@@ -20214,23 +18747,6 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
-    "node_modules/traverse": {
-      "version": "0.6.11",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.11.tgz",
-      "integrity": "sha512-vxXDZg8/+p3gblxB6BhhG5yWVn1kGRlaL8O78UDXc3wRnPizB5g83dcvWV1jpDMIPnjZjOFuxlMmE82XJ4407w==",
-      "license": "MIT",
-      "dependencies": {
-        "gopd": "^1.2.0",
-        "typedarray.prototype.slice": "^1.0.5",
-        "which-typed-array": "^1.1.18"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -20239,6 +18755,18 @@
       "license": "MIT",
       "bin": {
         "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/tree-sitter": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.21.1.tgz",
+      "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^8.0.0",
+        "node-gyp-build": "^4.8.0"
       }
     },
     "node_modules/tree-sitter-json": {
@@ -20259,17 +18787,6 @@
         "tree-sitter": {
           "optional": true
         }
-      }
-    },
-    "node_modules/tree-sitter-yaml": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/tree-sitter-yaml/-/tree-sitter-yaml-0.5.0.tgz",
-      "integrity": "sha512-POJ4ZNXXSWIG/W4Rjuyg36MkUD4d769YRUGKRqN+sVaj/VCo6Dh6Pkssn1Rtewd5kybx+jT1BWMyWN0CijXnMA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "nan": "^2.14.0"
       }
     },
     "node_modules/triple-beam": {
@@ -20432,26 +18949,6 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
-      "dev": true,
-      "license": "Unlicense"
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -20493,6 +18990,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
       "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -20507,6 +19005,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
       "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -20526,6 +19025,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
       "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
@@ -20547,6 +19047,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
       "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -20555,28 +19056,6 @@
         "is-typed-array": "^1.1.13",
         "possible-typed-array-names": "^1.0.0",
         "reflect.getprototypeof": "^1.0.6"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/typedarray.prototype.slice": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/typedarray.prototype.slice/-/typedarray.prototype.slice-1.0.5.tgz",
-      "integrity": "sha512-q7QNVDGTdl702bVFiI5eY4l/HkgCM6at9KhcFbgUAzezHFbOVy4+0O/lCjsABEQwbZPravVfBIiBVGo89yzHFg==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.9",
-        "es-errors": "^1.3.0",
-        "get-proto": "^1.0.1",
-        "math-intrinsics": "^1.1.0",
-        "typed-array-buffer": "^1.0.3",
-        "typed-array-byte-offset": "^1.0.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -20636,6 +19115,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
       "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -20802,19 +19282,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/url": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
-      "integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^1.4.1",
-        "qs": "^6.12.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/url-parse": {
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
@@ -20906,16 +19373,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/wcwidth": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "defaults": "^1.0.3"
       }
     },
     "node_modules/web-streams-polyfill": {
@@ -21057,6 +19514,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
       "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-bigint": "^1.1.0",
@@ -21076,6 +19534,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
       "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -21103,6 +19562,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
       "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-map": "^2.0.3",
@@ -21116,13 +19576,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/which-module": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
-      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/which-typed-array": {
       "version": "1.1.19",
@@ -21211,7 +19664,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
@@ -21226,28 +19679,6 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/xml-js": {
@@ -21271,112 +19702,12 @@
         "node": ">=0.4"
       }
     },
-    "node_modules/y18n": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yargs": {
-      "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^6.0.0",
-        "decamelize": "^1.2.0",
-        "find-up": "^4.1.0",
-        "get-caller-file": "^2.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^4.2.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^18.1.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "18.1.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/yargs/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/yargs/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/yargs/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yargs/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@aligent/ts-code-standards": "^4.2.0",
     "@babel/preset-env": "^7.26.9",
     "@babel/preset-typescript": "^7.27.0",
-    "@openwhisk/wskdebug": "^1.3.0",
     "@types/node": "^22.14.0",
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.1.2",


### PR DESCRIPTION
Also update remaining packages with published vulnerabilities.


**Description of the proposed changes**
The `@openwhisk/wskdebug` package has not been updated in a number of years, and brings in high-level vulnerabilities via dependencies (`tar-fs` via `dockerode`). Since the functionality provided by the package is of limited value, we should be able to remove it entirely.

Additional changes were made by running `npm audit fix`, resolving minor issues relating to the `cookie` and `brace-expansion` packages.

- **Screenshots (if applicable)**
<img width="1337" height="558" alt="image" src="https://github.com/user-attachments/assets/89c4630a-719c-4b46-93fa-ca607a4aa3ee" />


- **Other solutions considered (if any)**
It would be possible to fork the `wskdebug` package and maintain it ourselves, but, since it is mostly unused, the cost would outweigh the benefit.

**Notes to reviewers**

🛈 When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback
