### PR TITLE
Fix resolving of public packages to public npm registry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -865,7 +865,7 @@
     },
     "node_modules/@adobe/react-spectrum": {
       "version": "3.46.1",
-      "resolved": "https://npm.corp.aligent.consulting/@adobe/react-spectrum/-/react-spectrum-3.46.1.tgz",
+      "resolved": "https://registry.npmjs.org/@adobe/react-spectrum/-/react-spectrum-3.46.1.tgz",
       "integrity": "sha512-LzYWZn3YP6AvRnMLunOX/tAKRW30QCxJIViU/bEPtrSNQi3Qvs/5XETlI24dXT24v/wQ0HZJA7LGYf3iSHE+Hg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -941,7 +941,7 @@
     },
     "node_modules/@adobe/react-spectrum-ui": {
       "version": "1.2.1",
-      "resolved": "https://npm.corp.aligent.consulting/@adobe/react-spectrum-ui/-/react-spectrum-ui-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@adobe/react-spectrum-ui/-/react-spectrum-ui-1.2.1.tgz",
       "integrity": "sha512-wcrbEE2O/9WnEn6avBnaVRRx88S5PLFsPLr4wffzlbMfXeQsy+RMQwaJd3cbzrn18/j04Isit7f7Emfn0dhrJA==",
       "license": "Apache-2.0",
       "peerDependencies": {
@@ -951,7 +951,7 @@
     },
     "node_modules/@adobe/react-spectrum-workflow": {
       "version": "2.3.5",
-      "resolved": "https://npm.corp.aligent.consulting/@adobe/react-spectrum-workflow/-/react-spectrum-workflow-2.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/@adobe/react-spectrum-workflow/-/react-spectrum-workflow-2.3.5.tgz",
       "integrity": "sha512-b53VIPwPWKb/T5gzE3qs+QlGP5gVrw/LnWV3xMksDU+CRl3rzOKUwxIGiZO8ICyYh1WiyqY4myGlPU/nAynBUg==",
       "license": "Apache-2.0",
       "peerDependencies": {
@@ -3355,7 +3355,7 @@
     },
     "node_modules/@formatjs/ecma402-abstract": {
       "version": "2.3.6",
-      "resolved": "https://npm.corp.aligent.consulting/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
       "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
       "license": "MIT",
       "dependencies": {
@@ -3367,7 +3367,7 @@
     },
     "node_modules/@formatjs/fast-memoize": {
       "version": "2.2.7",
-      "resolved": "https://npm.corp.aligent.consulting/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
       "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
       "license": "MIT",
       "dependencies": {
@@ -3376,7 +3376,7 @@
     },
     "node_modules/@formatjs/icu-messageformat-parser": {
       "version": "2.11.4",
-      "resolved": "https://npm.corp.aligent.consulting/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
       "integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
       "license": "MIT",
       "dependencies": {
@@ -3387,7 +3387,7 @@
     },
     "node_modules/@formatjs/icu-skeleton-parser": {
       "version": "1.8.16",
-      "resolved": "https://npm.corp.aligent.consulting/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
       "integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
       "license": "MIT",
       "dependencies": {
@@ -3397,7 +3397,7 @@
     },
     "node_modules/@formatjs/intl-localematcher": {
       "version": "0.6.2",
-      "resolved": "https://npm.corp.aligent.consulting/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
       "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
       "license": "MIT",
       "dependencies": {
@@ -3619,7 +3619,7 @@
     },
     "node_modules/@internationalized/date": {
       "version": "3.11.0",
-      "resolved": "https://npm.corp.aligent.consulting/@internationalized/date/-/date-3.11.0.tgz",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.11.0.tgz",
       "integrity": "sha512-BOx5huLAWhicM9/ZFs84CzP+V3gBW6vlpM02yzsdYC7TGlZJX1OJiEEHcSayF00Z+3jLlm4w79amvSt6RqKN3Q==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -3628,7 +3628,7 @@
     },
     "node_modules/@internationalized/message": {
       "version": "3.1.8",
-      "resolved": "https://npm.corp.aligent.consulting/@internationalized/message/-/message-3.1.8.tgz",
+      "resolved": "https://registry.npmjs.org/@internationalized/message/-/message-3.1.8.tgz",
       "integrity": "sha512-Rwk3j/TlYZhn3HQ6PyXUV0XP9Uv42jqZGNegt0BXlxjE6G3+LwHjbQZAGHhCnCPdaA6Tvd3ma/7QzLlLkJxAWA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -3638,7 +3638,7 @@
     },
     "node_modules/@internationalized/number": {
       "version": "3.6.5",
-      "resolved": "https://npm.corp.aligent.consulting/@internationalized/number/-/number-3.6.5.tgz",
+      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.5.tgz",
       "integrity": "sha512-6hY4Kl4HPBvtfS62asS/R22JzNNy8vi/Ssev7x6EobfCp+9QIB2hKvI2EtbdJ0VSQacxVNtqhE/NmF/NZ0gm6g==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -3647,7 +3647,7 @@
     },
     "node_modules/@internationalized/string": {
       "version": "3.2.7",
-      "resolved": "https://npm.corp.aligent.consulting/@internationalized/string/-/string-3.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.7.tgz",
       "integrity": "sha512-D4OHBjrinH+PFZPvfCXvG28n2LSykWcJ7GIioQL+ok0LON15SdfoUssoHzzOUmVZLbRoREsQXVzA6r8JKsbP6A==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -5749,7 +5749,7 @@
     },
     "node_modules/@react-aria/actiongroup": {
       "version": "3.7.23",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/actiongroup/-/actiongroup-3.7.23.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/actiongroup/-/actiongroup-3.7.23.tgz",
       "integrity": "sha512-CQyswtH0CWCJPYlAz39TUS3H0eA1Xplx4GalF71BYcFG6U6mbawgtiUHPNj9sXdUSwY3Pb2K2FBk3cEtk/fySQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -5769,7 +5769,7 @@
     },
     "node_modules/@react-aria/autocomplete": {
       "version": "3.0.0-rc.5",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/autocomplete/-/autocomplete-3.0.0-rc.5.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/autocomplete/-/autocomplete-3.0.0-rc.5.tgz",
       "integrity": "sha512-qcGr/ZlSJxw78QtXB29MnvCwGZKlJ5FGfSICjaX/KIg4ONGFR/u4QjP/axA+vhlPa9Ik7BNeikWQriTcYrkbhw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -5795,7 +5795,7 @@
     },
     "node_modules/@react-aria/breadcrumbs": {
       "version": "3.5.31",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/breadcrumbs/-/breadcrumbs-3.5.31.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/breadcrumbs/-/breadcrumbs-3.5.31.tgz",
       "integrity": "sha512-j8F2NMHFGT/n3alfFKdO4bvrY/ymtdL04GdclY7Vc6zOmCnWoEZ2UA0sFuV7Rk9dOL8fAtYV1kMD1ZRO/EMcGA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -5813,7 +5813,7 @@
     },
     "node_modules/@react-aria/button": {
       "version": "3.14.4",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/button/-/button-3.14.4.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/button/-/button-3.14.4.tgz",
       "integrity": "sha512-6mTPiSSQhELnWlnYJ1Tm1B0VL1GGKAs2PGAY3ZGbPGQPPDc6Wu82yIhuAO8TTFJrXkwAiqjQawgDLil/yB0V7Q==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -5832,7 +5832,7 @@
     },
     "node_modules/@react-aria/calendar": {
       "version": "3.9.4",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/calendar/-/calendar-3.9.4.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/calendar/-/calendar-3.9.4.tgz",
       "integrity": "sha512-0BvU8cj6uHn622Vp8Xd21XxXtvp3Bh4Yk1pHloqDNmUvvdBN+ol3Xsm5gG3XKKkZ+6CCEi6asCbLaEg3SZSbyg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -5854,7 +5854,7 @@
     },
     "node_modules/@react-aria/checkbox": {
       "version": "3.16.4",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/checkbox/-/checkbox-3.16.4.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/checkbox/-/checkbox-3.16.4.tgz",
       "integrity": "sha512-FcZj6/f27mNp2+G5yxyOMRZbZQjJ1cuWvo0PPnnZ4ybSPUmSzI4uUZBk1wvsJVP9F9n+J2hZuYVCaN8pyzLweA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -5877,7 +5877,7 @@
     },
     "node_modules/@react-aria/collections": {
       "version": "3.0.2",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/collections/-/collections-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/collections/-/collections-3.0.2.tgz",
       "integrity": "sha512-5GV0fj1bvfdztHozlZQ1nzdmcZOAOdZ5BhwrSyuHbK5ptmQrpAoWUK+VTQlxkAfyn5i6niaaN/llP1v3RgEemw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -5895,7 +5895,7 @@
     },
     "node_modules/@react-aria/color": {
       "version": "3.1.4",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/color/-/color-3.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/color/-/color-3.1.4.tgz",
       "integrity": "sha512-LNFo0A9EEn2HZ8O/hASschH++M+krfezcp01XPv0/2ZQJ5b5u7VvJlUOEXtPsD4i9+BzvkSAEoVUXdlJie9V2Q==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -5920,7 +5920,7 @@
     },
     "node_modules/@react-aria/combobox": {
       "version": "3.14.2",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/combobox/-/combobox-3.14.2.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/combobox/-/combobox-3.14.2.tgz",
       "integrity": "sha512-qwBeb8cMgK3xwrvXYHPtcphduD/k+oTcU18JHPvEO2kmR32knB33H81C2/Zoh4x86zTDJXaEtPscXBWuQ/M7AQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -5948,7 +5948,7 @@
     },
     "node_modules/@react-aria/datepicker": {
       "version": "3.16.0",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/datepicker/-/datepicker-3.16.0.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/datepicker/-/datepicker-3.16.0.tgz",
       "integrity": "sha512-QynYHIHE+wvuGopl/k05tphmDpykpfZ3l3eKnUfGrqvAYJEeCOyS0qoMlw7Vq3NscMLFbJI6ajqBmlmtgFNiSA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -5978,7 +5978,7 @@
     },
     "node_modules/@react-aria/dialog": {
       "version": "3.5.33",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/dialog/-/dialog-3.5.33.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/dialog/-/dialog-3.5.33.tgz",
       "integrity": "sha512-C5FpLAMJU6gQU8gztWKlEJ2A0k/JKl0YijNOv3Lizk+vUdF5njROSrmFs16bY5Hd6ycmsK9x/Pqkq3m/OpNFXA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -5996,7 +5996,7 @@
     },
     "node_modules/@react-aria/disclosure": {
       "version": "3.1.2",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/disclosure/-/disclosure-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/disclosure/-/disclosure-3.1.2.tgz",
       "integrity": "sha512-UQ/CmWcdcROfRTMtvfsnYHrEsPPNbwZifZ/UErQpbvU4kzal2N+PpuP3+kpdf4G7TeMt+uJ8S9dLzyFVijOj9A==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6013,7 +6013,7 @@
     },
     "node_modules/@react-aria/dnd": {
       "version": "3.11.5",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/dnd/-/dnd-3.11.5.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/dnd/-/dnd-3.11.5.tgz",
       "integrity": "sha512-3IGrABfK8Cf6/b/uEmGEDGeubWKMUK3umWunF/tdkWBnIaxpdj4gRkWFMw7siWQYnqir6AN567nrWXtHFcLKsA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6036,7 +6036,7 @@
     },
     "node_modules/@react-aria/focus": {
       "version": "3.21.4",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/focus/-/focus-3.21.4.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.21.4.tgz",
       "integrity": "sha512-6gz+j9ip0/vFRTKJMl3R30MHopn4i19HqqLfSQfElxJD+r9hBnYG1Q6Wd/kl/WRR1+CALn2F+rn06jUnf5sT8Q==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6053,7 +6053,7 @@
     },
     "node_modules/@react-aria/form": {
       "version": "3.1.4",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/form/-/form-3.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/form/-/form-3.1.4.tgz",
       "integrity": "sha512-GjPS85cE/34zal3vs6MOi7FxUsXwbxN4y6l1LFor2g92UK97gVobp238f3xdMW2T8IuaWGcnHeYFg+cjiZ51pQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6070,7 +6070,7 @@
     },
     "node_modules/@react-aria/grid": {
       "version": "3.14.7",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/grid/-/grid-3.14.7.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/grid/-/grid-3.14.7.tgz",
       "integrity": "sha512-8eaJThNHUs75Xf4+FQC2NKQtTOVYkkDdA8VbfbqG06oYDAn7ETb1yhbwoqh1jOv7MezCNkYjyFe4ADsz2rBVcw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6095,7 +6095,7 @@
     },
     "node_modules/@react-aria/gridlist": {
       "version": "3.14.3",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/gridlist/-/gridlist-3.14.3.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/gridlist/-/gridlist-3.14.3.tgz",
       "integrity": "sha512-t3nr29nU5jRG9MdWe9aiMd02V8o0pmidLU/7c4muWAu7hEH+IYdeDthGDdXL9tXAom/oQ+6yt6sOfLxpsVNmGA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6117,7 +6117,7 @@
     },
     "node_modules/@react-aria/i18n": {
       "version": "3.12.15",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/i18n/-/i18n-3.12.15.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/i18n/-/i18n-3.12.15.tgz",
       "integrity": "sha512-3CrAN7ORVHrckvTmbPq76jFZabqq+rScosGT5+ElircJ5rF5+JcdT99Hp5Xg6R10jk74e8G3xiqdYsUd+7iJMA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6137,7 +6137,7 @@
     },
     "node_modules/@react-aria/interactions": {
       "version": "3.27.0",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/interactions/-/interactions-3.27.0.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.27.0.tgz",
       "integrity": "sha512-D27pOy+0jIfHK60BB26AgqjjRFOYdvVSkwC31b2LicIzRCSPOSP06V4gMHuGmkhNTF4+YWDi1HHYjxIvMeiSlA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6154,7 +6154,7 @@
     },
     "node_modules/@react-aria/label": {
       "version": "3.7.24",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/label/-/label-3.7.24.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/label/-/label-3.7.24.tgz",
       "integrity": "sha512-lcJbUy6xyicWKNgzfrXksrJ2CeCST2rDxGAvHOmUxSbFOm26kK710DjaFvtO4tICWh/TKW5mC3sm77soNcVUGA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6169,7 +6169,7 @@
     },
     "node_modules/@react-aria/landmark": {
       "version": "3.0.9",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/landmark/-/landmark-3.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/landmark/-/landmark-3.0.9.tgz",
       "integrity": "sha512-YYyluDBCXupnMh91ccE5g27fczjYmzPebHqTkVYjH4B6k45pOoqsMmWBCMnOTl0qOCeioI+daT8W0MamAZzoSw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6185,7 +6185,7 @@
     },
     "node_modules/@react-aria/link": {
       "version": "3.8.8",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/link/-/link-3.8.8.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/link/-/link-3.8.8.tgz",
       "integrity": "sha512-hxQEvo5rrn2C0GOSwB/tROe+y//dyhmyXGbm8arDy6WF5Mj0wcjjrAu0/dhGYBqoltJa16iIEvs52xgzOC+f+Q==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6202,7 +6202,7 @@
     },
     "node_modules/@react-aria/listbox": {
       "version": "3.15.2",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/listbox/-/listbox-3.15.2.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/listbox/-/listbox-3.15.2.tgz",
       "integrity": "sha512-xcrgSediV8MaVmsuDrDPmWywF82/HOv+H+Y/dgr6GLCWl0XDj5Q7PyAhDzUsYdZNIne3B9muGh6IQc3HdkgWqg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6223,7 +6223,7 @@
     },
     "node_modules/@react-aria/live-announcer": {
       "version": "3.4.4",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/live-announcer/-/live-announcer-3.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/live-announcer/-/live-announcer-3.4.4.tgz",
       "integrity": "sha512-PTTBIjNRnrdJOIRTDGNifY2d//kA7GUAwRFJNOEwSNG4FW+Bq9awqLiflw0JkpyB0VNIwou6lqKPHZVLsGWOXA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6232,7 +6232,7 @@
     },
     "node_modules/@react-aria/menu": {
       "version": "3.20.0",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/menu/-/menu-3.20.0.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/menu/-/menu-3.20.0.tgz",
       "integrity": "sha512-BAsHuf7kTVmawNUkTUd5RB3ZvL6DQQT7hgZ2cYKd/1ZwYq4KO2wWGYdzyTOtK1qimZL0eyHyQwDYv4dNKBH4gw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6258,7 +6258,7 @@
     },
     "node_modules/@react-aria/meter": {
       "version": "3.4.29",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/meter/-/meter-3.4.29.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/meter/-/meter-3.4.29.tgz",
       "integrity": "sha512-XAhJf8LlYQl+QQXqtpWvzjlrT8MZKEG6c8N3apC5DONgSKlCwfmDm4laGEJPqtuz3QGiOopsfSfyTFYHjWsfZw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6274,7 +6274,7 @@
     },
     "node_modules/@react-aria/numberfield": {
       "version": "3.12.4",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/numberfield/-/numberfield-3.12.4.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/numberfield/-/numberfield-3.12.4.tgz",
       "integrity": "sha512-TgKBjKOjyURzbqNR2wF4tSFmQKNK5DqE4QZSlQxpYYo1T6zuztkh+oTOUZ4IWCJymL5qLtuPfGHCZbR7B+DN2w==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6297,7 +6297,7 @@
     },
     "node_modules/@react-aria/overlays": {
       "version": "3.31.1",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/overlays/-/overlays-3.31.1.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/overlays/-/overlays-3.31.1.tgz",
       "integrity": "sha512-U5BedzcXU97U5PWm4kIPnNoVpAs9KjTYfbkGx33vapmTVpGYhQyYW9eg6zW2E8ZKsyFJtQ/jkQnbWGen97aHSQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6320,7 +6320,7 @@
     },
     "node_modules/@react-aria/progress": {
       "version": "3.4.29",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/progress/-/progress-3.4.29.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/progress/-/progress-3.4.29.tgz",
       "integrity": "sha512-orSaaFLX5LdD9UyxgBrmP1J/ivyEFX+5v4ENPQM5RH5+Hl+0OJa+8ozI0AfVKBqCYc89BOZfG7kzi7wFHACZcQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6338,7 +6338,7 @@
     },
     "node_modules/@react-aria/radio": {
       "version": "3.12.4",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/radio/-/radio-3.12.4.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/radio/-/radio-3.12.4.tgz",
       "integrity": "sha512-2sjBAE8++EtAAfjwPdrqEVswbzR4Mvcy4n8SvwUxTo02yESa9nolBzCSdAUFUmhrNj3MiMA+zLxQ+KACfUjJOg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6360,7 +6360,7 @@
     },
     "node_modules/@react-aria/searchfield": {
       "version": "3.8.11",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/searchfield/-/searchfield-3.8.11.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/searchfield/-/searchfield-3.8.11.tgz",
       "integrity": "sha512-5R0prEC+jRFwPeJsK6G4RN8QG3V/+EaIuw9p79G1gFD+1dY81ZakiZIIJaLWRyO7AzYBGyC/QFHtz0m3KGQT/Q==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6380,7 +6380,7 @@
     },
     "node_modules/@react-aria/select": {
       "version": "3.17.2",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/select/-/select-3.17.2.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/select/-/select-3.17.2.tgz",
       "integrity": "sha512-oMpHStyMluRf67qxrzH5Qfcvw6ETQgZT1Qw2xvAxQVRd5IBb0PfzZS7TGiULOcMLqXAUOC28O/ycUGrGRKLarg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6406,7 +6406,7 @@
     },
     "node_modules/@react-aria/selection": {
       "version": "3.27.1",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/selection/-/selection-3.27.1.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/selection/-/selection-3.27.1.tgz",
       "integrity": "sha512-8WQ4AtWiBnk9UEeYkqpH12dd8KQW2aFbNZvM4sDfLtz7K7HWyY/MkqMe/snk9IcoSa7t4zr0bnoZJcWSGgn2PQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6425,7 +6425,7 @@
     },
     "node_modules/@react-aria/separator": {
       "version": "3.4.15",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/separator/-/separator-3.4.15.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/separator/-/separator-3.4.15.tgz",
       "integrity": "sha512-A1aPQhCaE8XeelNJYPjHtA2uh921ROh8PNiZI4o62x80wcziRoctN5PAtNHJAx7VKvX66A8ZVGbOqb7iqS3J5Q==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6440,7 +6440,7 @@
     },
     "node_modules/@react-aria/slider": {
       "version": "3.8.4",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/slider/-/slider-3.8.4.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/slider/-/slider-3.8.4.tgz",
       "integrity": "sha512-/FYCgK1qVqaz2VCDfR2x4BjyJ8lmWg1v8//+WIwKdIu4cz0KUs+U3yx0w1vp676RoERp3OEvkT3tb+/jHQ1hjA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6460,7 +6460,7 @@
     },
     "node_modules/@react-aria/spinbutton": {
       "version": "3.7.1",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/spinbutton/-/spinbutton-3.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/spinbutton/-/spinbutton-3.7.1.tgz",
       "integrity": "sha512-Nisah6yzxOC6983u/5ck0w+OQoa3sRKmpDvWpTEX0g2+ZIABOl8ttdSd65XKtxXmXHdK8X1zmrfeGOBfBR3sKA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6478,7 +6478,7 @@
     },
     "node_modules/@react-aria/ssr": {
       "version": "3.9.10",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/ssr/-/ssr-3.9.10.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.10.tgz",
       "integrity": "sha512-hvTm77Pf+pMBhuBm760Li0BVIO38jv1IBws1xFm1NoL26PU+fe+FMW5+VZWyANR6nYL65joaJKZqOdTQMkO9IQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6493,7 +6493,7 @@
     },
     "node_modules/@react-aria/switch": {
       "version": "3.7.10",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/switch/-/switch-3.7.10.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/switch/-/switch-3.7.10.tgz",
       "integrity": "sha512-j7nrYnqX6H9J8GuqD0kdMECUozeqxeG19A2nsvfaTx3//Q7RhgIR9fqhQdVHW/wgraTlEHNH6AhDzmomBg0TNw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6510,7 +6510,7 @@
     },
     "node_modules/@react-aria/table": {
       "version": "3.17.10",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/table/-/table-3.17.10.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/table/-/table-3.17.10.tgz",
       "integrity": "sha512-xdEeyOzuETkOfAHhZrX7HOIwMUsCUr4rbPvHqdcNqg7Ngla2ck9iulZNAyvOPfFwELuBEd2rz1I9TYRQ2OzSQQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6537,7 +6537,7 @@
     },
     "node_modules/@react-aria/tabs": {
       "version": "3.11.0",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/tabs/-/tabs-3.11.0.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/tabs/-/tabs-3.11.0.tgz",
       "integrity": "sha512-9Gwo118GHrMXSyteCZL1L/LHLVlGSYkhGgiTL3e/UgnYjHfEfDJVTkV2JikuE2O/4uig52gQRlq5E99axLeE9Q==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6557,7 +6557,7 @@
     },
     "node_modules/@react-aria/tag": {
       "version": "3.8.0",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/tag/-/tag-3.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/tag/-/tag-3.8.0.tgz",
       "integrity": "sha512-sTV6uRKFIFU1aljKb0QjM6fPPnzBuitrbkkCUZCJ0w0RIX1JinZPh96NknNtjFwWmqoROjVNCq51EUd0Hh2SQw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6579,7 +6579,7 @@
     },
     "node_modules/@react-aria/textfield": {
       "version": "3.18.4",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/textfield/-/textfield-3.18.4.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/textfield/-/textfield-3.18.4.tgz",
       "integrity": "sha512-ts3Vdy2qNOzjCVeO+4RH8FSgTYN2USAMcYFeGbHOriCukVOrvgRsqcDniW7xaT60LgFdlWMJsCusvltSIyo6xw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6600,7 +6600,7 @@
     },
     "node_modules/@react-aria/toast": {
       "version": "3.0.10",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/toast/-/toast-3.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/toast/-/toast-3.0.10.tgz",
       "integrity": "sha512-irW5Cr4msbPo4A4ysjT70MDJbpGCe1h9SkFgdYXBPA4Xbi4jRT7TiEZeIS1I7Hsvp6shAK1Ld/m6NBS0b/gyzg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6620,7 +6620,7 @@
     },
     "node_modules/@react-aria/toggle": {
       "version": "3.12.4",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/toggle/-/toggle-3.12.4.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/toggle/-/toggle-3.12.4.tgz",
       "integrity": "sha512-yVcl8kEFLsV47aCA22EMPcd/KWoYqPIPSzoKjRD/iWmxcP6iGzSxDjdUgMQojNGY8Q6wL8lUxfRqKBjvl/uezQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6638,7 +6638,7 @@
     },
     "node_modules/@react-aria/toolbar": {
       "version": "3.0.0-beta.23",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/toolbar/-/toolbar-3.0.0-beta.23.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/toolbar/-/toolbar-3.0.0-beta.23.tgz",
       "integrity": "sha512-FzvNf2hWtjEwk8F2MBf4qSs6AAR/p2WFSws6kJ4f0SrWXl4wR9VDEwBEUQcIPbWCK2aUsyOjubCh55Cl4t3MoQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6655,7 +6655,7 @@
     },
     "node_modules/@react-aria/tooltip": {
       "version": "3.9.1",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/tooltip/-/tooltip-3.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/tooltip/-/tooltip-3.9.1.tgz",
       "integrity": "sha512-mvEhqpvF4v/wj9zw3a8bsAEnySutGbxKXXt39s6WvF6dkVfaXfsmV9ahuMCHH//UGh/yidZGLrXX4YVdrgS8lA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6673,7 +6673,7 @@
     },
     "node_modules/@react-aria/tree": {
       "version": "3.1.6",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/tree/-/tree-3.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/tree/-/tree-3.1.6.tgz",
       "integrity": "sha512-igLX+OQrbXCBLrtPWgUevU0iDrgTSAJh1ncHoPzfD/YDcyTDLqKdy2nZhNbJ/IdHCwTyzIknhFJ700K20Ymw9A==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6693,7 +6693,7 @@
     },
     "node_modules/@react-aria/utils": {
       "version": "3.33.0",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/utils/-/utils-3.33.0.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.33.0.tgz",
       "integrity": "sha512-yvz7CMH8d2VjwbSa5nGXqjU031tYhD8ddax95VzJsHSPyqHDEGfxul8RkhGV6oO7bVqZxVs6xY66NIgae+FHjw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6711,7 +6711,7 @@
     },
     "node_modules/@react-aria/virtualizer": {
       "version": "4.1.12",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/virtualizer/-/virtualizer-4.1.12.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/virtualizer/-/virtualizer-4.1.12.tgz",
       "integrity": "sha512-va0VAD28nq7rk1vHZvnkq591EbWuDKBwh2NzAEn+zz9JjMtpg4utcihNXECJ1DwMRkpaT6q+KpOE7dSdzTxPBQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6729,7 +6729,7 @@
     },
     "node_modules/@react-aria/visually-hidden": {
       "version": "3.8.30",
-      "resolved": "https://npm.corp.aligent.consulting/@react-aria/visually-hidden/-/visually-hidden-3.8.30.tgz",
+      "resolved": "https://registry.npmjs.org/@react-aria/visually-hidden/-/visually-hidden-3.8.30.tgz",
       "integrity": "sha512-iY44USEU8sJy0NOJ/sTDn3YlspbhHuVG3nx2YYrzfmxbS3i+lNwkCfG8kJ77dtmbuDLIdBGKENjGkbcwz3kiJg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6745,7 +6745,7 @@
     },
     "node_modules/@react-spectrum/accordion": {
       "version": "3.0.15",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/accordion/-/accordion-3.0.15.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/accordion/-/accordion-3.0.15.tgz",
       "integrity": "sha512-8A2Hs4tIxeMi8zEqwo4QMyi1CW2sRXoRsDrmAGN8NxOzUyGgyaFOOlfCk3xYTMazHG84zbucLFSOmDReN8KPhQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6764,7 +6764,7 @@
     },
     "node_modules/@react-spectrum/actionbar": {
       "version": "3.6.16",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/actionbar/-/actionbar-3.6.16.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/actionbar/-/actionbar-3.6.16.tgz",
       "integrity": "sha512-LS2DDpupXgpTmNcLgNGpaMjKLy1aTSlizm6sU+GxJurkwY1PnXFTR4zoBbGO5IlL8NptaFAvO+noINjc1mPjGw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6792,7 +6792,7 @@
     },
     "node_modules/@react-spectrum/actiongroup": {
       "version": "3.11.6",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/actiongroup/-/actiongroup-3.11.6.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/actiongroup/-/actiongroup-3.11.6.tgz",
       "integrity": "sha512-d3NQDYKCDzwTMOdq+rL1MDy84QDgkxaz4gfzqox72Uj1ezUJ/5BEZFq0vzge+cOyO4yRUUiBv+bmhgV44b3/wQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6822,7 +6822,7 @@
     },
     "node_modules/@react-spectrum/avatar": {
       "version": "3.0.28",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/avatar/-/avatar-3.0.28.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/avatar/-/avatar-3.0.28.tgz",
       "integrity": "sha512-ZdJqXHXSGM1L4YX/nzVjfa/XmG0ll2Nd5tJ3tKHUhWR5+cBR5rVXc1jYO6RIKGHvJ9nh58O6S3L8RmHzoeKhkA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6840,7 +6840,7 @@
     },
     "node_modules/@react-spectrum/badge": {
       "version": "3.1.32",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/badge/-/badge-3.1.32.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/badge/-/badge-3.1.32.tgz",
       "integrity": "sha512-t0TV3ZyOVI/dDN36nZ6P6jbGFsMAiCwaH0TqPnq+cpeCWwcupQDQ8tIuq5zo9+Eu22SWjXMHK9w2XbF3PhAB3Q==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6859,7 +6859,7 @@
     },
     "node_modules/@react-spectrum/breadcrumbs": {
       "version": "3.9.26",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/breadcrumbs/-/breadcrumbs-3.9.26.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/breadcrumbs/-/breadcrumbs-3.9.26.tgz",
       "integrity": "sha512-9t5ZdDhCuQJNXiPT0DazaJTGg9V0vfa5dWnVghqsL2Q2rdYSvD5WUZ8M0XGJeyXsVqbpzVR5o+RyQgNOUtsBDg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6885,7 +6885,7 @@
     },
     "node_modules/@react-spectrum/button": {
       "version": "3.17.6",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/button/-/button-3.17.6.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/button/-/button-3.17.6.tgz",
       "integrity": "sha512-/1sWaHUVLHNsrE0TR+c3qIfcTFJq4hscokq76waZ6mO1IeuL4nVEBx0c7k3qQPQ0VvyEthkve+nb6bD74lFFGA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6911,7 +6911,7 @@
     },
     "node_modules/@react-spectrum/buttongroup": {
       "version": "3.6.28",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/buttongroup/-/buttongroup-3.6.28.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/buttongroup/-/buttongroup-3.6.28.tgz",
       "integrity": "sha512-kj0B0iMIzWde0DKrEDyesK2C1CAmwXvtoXVVFV4x7Yxg63myIbkW1PX2iOpak30ii+gVZwKqlf/LZtoKt+3NyQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6929,7 +6929,7 @@
     },
     "node_modules/@react-spectrum/calendar": {
       "version": "3.7.10",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/calendar/-/calendar-3.7.10.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/calendar/-/calendar-3.7.10.tgz",
       "integrity": "sha512-iwp1HKc8lCl/UptROEXW+H0jRCx2If7O83gx3SEc7VJNuZKwDQ7bq9spFhoVxCZzLMDvaIg4K4CXn8pH/CNfFA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6958,7 +6958,7 @@
     },
     "node_modules/@react-spectrum/checkbox": {
       "version": "3.10.6",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/checkbox/-/checkbox-3.10.6.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/checkbox/-/checkbox-3.10.6.tgz",
       "integrity": "sha512-EpKW3diLzj6BFtkSsiD2eezT9RG6sdA1xJC74w9Rs0yIRBtXIDLegxX2dEQWzdW1IyrUgcrHYFydgwyxpMTlwA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6984,7 +6984,7 @@
     },
     "node_modules/@react-spectrum/color": {
       "version": "3.1.6",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/color/-/color-3.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/color/-/color-3.1.6.tgz",
       "integrity": "sha512-T6mdyZh0cAAvmsDks1gPu4eisNRwlwkuv6N99aF0HYuVme5pziQs81InQ5LHwKTpuZlk5CAdfYP2TYqlItuvbA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7016,7 +7016,7 @@
     },
     "node_modules/@react-spectrum/combobox": {
       "version": "3.16.6",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/combobox/-/combobox-3.16.6.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/combobox/-/combobox-3.16.6.tgz",
       "integrity": "sha512-yyAxPnTSK0+AfNaahaF8JdhQVPlFHq0sNcn9u4EO/XVaCOOl7DVUnRA6nqz7sMcXJnDcST85EKWAL4eY6ZTk2A==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7054,7 +7054,7 @@
     },
     "node_modules/@react-spectrum/contextualhelp": {
       "version": "3.6.30",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/contextualhelp/-/contextualhelp-3.6.30.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/contextualhelp/-/contextualhelp-3.6.30.tgz",
       "integrity": "sha512-KcPRqy9Nl/WtLNgj+orY77akvAQ5dZDXOlP1WF1YT+EJnRv7RNh/a/nRbhaD6cLHOcY7KgXRbxjQQ5Z5cM8IRg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7076,7 +7076,7 @@
     },
     "node_modules/@react-spectrum/datepicker": {
       "version": "3.14.10",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/datepicker/-/datepicker-3.14.10.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/datepicker/-/datepicker-3.14.10.tgz",
       "integrity": "sha512-ZVY6TBa88TUNAyY12lvOF3OTr1vJ7NV7J6cRTB0aHtHN4ex+KY5bUSrr/B/OkPGA2etKwmNSJuWNciiqsV/4Pg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7109,7 +7109,7 @@
     },
     "node_modules/@react-spectrum/dialog": {
       "version": "3.9.6",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/dialog/-/dialog-3.9.6.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/dialog/-/dialog-3.9.6.tgz",
       "integrity": "sha512-onV/loLozp9e3gs2+zJkQvQUFWk5zsTWw6YfKia+46bAAQ8xxfyTjB2l/LraJaa0/2C9XiFENMVpy+nDdmHdWA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7141,7 +7141,7 @@
     },
     "node_modules/@react-spectrum/divider": {
       "version": "3.5.29",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/divider/-/divider-3.5.29.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/divider/-/divider-3.5.29.tgz",
       "integrity": "sha512-dtfZRsJ0BZFv9gHhVhCkBvZyaPcXSwssYM4aUGWd4XkOJYf+Wtx1f+HGHIS1yz7EVCPbmqV3K/gnOo8TrIp3Bw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7158,7 +7158,7 @@
     },
     "node_modules/@react-spectrum/dnd": {
       "version": "3.6.4",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/dnd/-/dnd-3.6.4.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/dnd/-/dnd-3.6.4.tgz",
       "integrity": "sha512-zydu2gE+8/fBMZMmZbCxWf3R4J7CWZBTj1XC6dxfCxyvk8egAzY2PV/7TSRpu7lj+VYmcK6xG3tFEX8afACqYw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7175,7 +7175,7 @@
     },
     "node_modules/@react-spectrum/dropzone": {
       "version": "3.0.20",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/dropzone/-/dropzone-3.0.20.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/dropzone/-/dropzone-3.0.20.tgz",
       "integrity": "sha512-XaMQvVzISem9YViKJ0vDSm9ZDHRQ8EIg5CAY+UL3VL8qWZWzNq+b9FOhL8ydTxSc72uGjnzIqI8bd4icqeYMvg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7194,7 +7194,7 @@
     },
     "node_modules/@react-spectrum/filetrigger": {
       "version": "3.0.20",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/filetrigger/-/filetrigger-3.0.20.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/filetrigger/-/filetrigger-3.0.20.tgz",
       "integrity": "sha512-XXagyN98D+Ne8lqDs7Md5SvzrkyW309xm2tgUt5kpn+OB14h8MeEbDpd5TLnsOyB1AyLpn4cr57zM+AKdBgd7Q==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7209,7 +7209,7 @@
     },
     "node_modules/@react-spectrum/form": {
       "version": "3.7.21",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/form/-/form-3.7.21.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/form/-/form-3.7.21.tgz",
       "integrity": "sha512-f2U+GeVNcm1uOhLQWSvnZxFR/yLcyNUjyrzh/c2/cqPI5FRH8KROp+GCTeBj6bFaAHVJymFemY0TthJAQlI0YQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7228,7 +7228,7 @@
     },
     "node_modules/@react-spectrum/icon": {
       "version": "3.8.11",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/icon/-/icon-3.8.11.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/icon/-/icon-3.8.11.tgz",
       "integrity": "sha512-kLeJbiNWfca+tWanFtTuUeujDb/BjHDDyNNikJcRD4Hu3o7/fW+9+S5ML6CNaWahwVrqkLX24aFVBE+bfPF8tg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7245,7 +7245,7 @@
     },
     "node_modules/@react-spectrum/illustratedmessage": {
       "version": "3.5.16",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/illustratedmessage/-/illustratedmessage-3.5.16.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/illustratedmessage/-/illustratedmessage-3.5.16.tgz",
       "integrity": "sha512-0rAXNJs29A0XjELJqKcADnHBewHkQt5CLHSFzcN+g7+1qWouy3sZgBF/4lCDOYmFbm1kKjqLmvLAVWyU4PO+pg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7264,7 +7264,7 @@
     },
     "node_modules/@react-spectrum/image": {
       "version": "3.6.4",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/image/-/image-3.6.4.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/image/-/image-3.6.4.tgz",
       "integrity": "sha512-Z4ASTih1nA69NcWd2f4H574QYq5CDYStou9wLuJdS+zB8PulfwyOZ8wua0Zu4wiCC6sNw5KfGlLnk/CXvAtKuQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7282,7 +7282,7 @@
     },
     "node_modules/@react-spectrum/inlinealert": {
       "version": "3.2.22",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/inlinealert/-/inlinealert-3.2.22.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/inlinealert/-/inlinealert-3.2.22.tgz",
       "integrity": "sha512-CTAnpu3IecKoOSAhkv667spDWh02f818Uh4VfXXGoFYj1sIB0ojzP1w0wldfTDbq2CgXzG6h8EqZgsgPStGEAg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7303,7 +7303,7 @@
     },
     "node_modules/@react-spectrum/label": {
       "version": "3.16.21",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/label/-/label-3.16.21.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/label/-/label-3.16.21.tgz",
       "integrity": "sha512-vccckkpL5eDysppJ3aLoaZVAn92P5AISk57J6kYuDrKl4U46MkZZSMXVWbN/rTngbLFfWEKl3bM6Ppu55GR2VA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7325,7 +7325,7 @@
     },
     "node_modules/@react-spectrum/labeledvalue": {
       "version": "3.2.9",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/labeledvalue/-/labeledvalue-3.2.9.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/labeledvalue/-/labeledvalue-3.2.9.tgz",
       "integrity": "sha512-2oHdGjdChAwWkjXzCFZsv4fLjy6E7e6jI/Nuo2rGqvd7s/uPXQM7s4YDN6DoCDw6OgVS42VOML/GYyOFKEiXlw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7345,7 +7345,7 @@
     },
     "node_modules/@react-spectrum/layout": {
       "version": "3.6.21",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/layout/-/layout-3.6.21.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/layout/-/layout-3.6.21.tgz",
       "integrity": "sha512-c5TX3E+wZvhM5uRBYg7WvXTL+WDCn6RRlsjlvnJUGQYQ0Qzyn18GgT2zJi3HvBGTaA5PVNfuAL8pBlSWprJZsg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7363,7 +7363,7 @@
     },
     "node_modules/@react-spectrum/link": {
       "version": "3.6.24",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/link/-/link-3.6.24.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/link/-/link-3.6.24.tgz",
       "integrity": "sha512-4rIx3H9Jc0KP4/IkfTaTfCExbM1Fq8U8lXkHnVauH1te8MVGgCUvyXH1qw4wULcTG2UqNsPgfV0G61ahMfA/6A==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7384,7 +7384,7 @@
     },
     "node_modules/@react-spectrum/list": {
       "version": "3.10.10",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/list/-/list-3.10.10.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/list/-/list-3.10.10.tgz",
       "integrity": "sha512-2VSwSb1c8ozUAuZv6D1jL2a2TPMRQTLxLxhB9VXlxxMInYHhRm+R8xLurmLmCJkbJ0O0U3xUrQjzz1ZcwwzlGA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7421,7 +7421,7 @@
     },
     "node_modules/@react-spectrum/listbox": {
       "version": "3.15.10",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/listbox/-/listbox-3.15.10.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/listbox/-/listbox-3.15.10.tgz",
       "integrity": "sha512-AfKa6+UEQWdD7r0vThU/qbhPl17Dibtgl38jPHnx4ZyGU3LjDtXkZSWNogGP6tvKjYJUM0F9NBbjEV8W6cRxzQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7452,7 +7452,7 @@
     },
     "node_modules/@react-spectrum/menu": {
       "version": "3.22.10",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/menu/-/menu-3.22.10.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/menu/-/menu-3.22.10.tgz",
       "integrity": "sha512-Z8nzRxcNegdaOhJrHNbLNCSJ3tYW8k/OiYZaK/Dg2cbGXKMmDvEaUEsbCz/1trfF3vP3Tw59RKh7wVv7w13Q1A==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7487,7 +7487,7 @@
     },
     "node_modules/@react-spectrum/meter": {
       "version": "3.5.16",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/meter/-/meter-3.5.16.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/meter/-/meter-3.5.16.tgz",
       "integrity": "sha512-NgAz/DuT81C03363emgoufurLzxzGKrpJWxqNXG2yWyokmV+Ou6Et+A+QSCPXkJgDzg/znwkJ7DL8y6R8AVpQA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7506,7 +7506,7 @@
     },
     "node_modules/@react-spectrum/numberfield": {
       "version": "3.10.4",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/numberfield/-/numberfield-3.10.4.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/numberfield/-/numberfield-3.10.4.tgz",
       "integrity": "sha512-IPt1cT1kabEgwLG1gIfUTViGV1llP0JMgP0YtfE3zymySizeT407UNNsbqL8RaWJLJ94Z2/8WJYeQB3dO0upWw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7536,7 +7536,7 @@
     },
     "node_modules/@react-spectrum/overlays": {
       "version": "5.9.2",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/overlays/-/overlays-5.9.2.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/overlays/-/overlays-5.9.2.tgz",
       "integrity": "sha512-0q2b9AosaTQpKjG3JVmvf0lGHI8Rz2nfQKcIZIa2Tj8m2MOmuCaFNYfnpsbXLyZpaZN16F/ZPlOKhmSfgnU5Lg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7558,7 +7558,7 @@
     },
     "node_modules/@react-spectrum/picker": {
       "version": "3.16.6",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/picker/-/picker-3.16.6.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/picker/-/picker-3.16.6.tgz",
       "integrity": "sha512-vvq0aten7oLceIAF0MFrLqJglFElEfzccRSxd6oS1nQt2+xaFVT1HfeaBILxjY18TCHigqXD9Pi9h+qfjMA2PQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7589,7 +7589,7 @@
     },
     "node_modules/@react-spectrum/progress": {
       "version": "3.7.22",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/progress/-/progress-3.7.22.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/progress/-/progress-3.7.22.tgz",
       "integrity": "sha512-eKfyQ6H2Oera8xmzNtcrW6mvwGo+skApddis74y/sX2A/RAXhE+64f5G/x3XCtKOSvGRtdxsiy1xC2pa0KseAA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7608,7 +7608,7 @@
     },
     "node_modules/@react-spectrum/provider": {
       "version": "3.10.13",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/provider/-/provider-3.10.13.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/provider/-/provider-3.10.13.tgz",
       "integrity": "sha512-Wu/UaoSuPKMfd44EYrl5z2Tw3Yd9bO9q12be5MylTMM/lplzIaUe1l/JrWMMJpIg7m/llR2Cj4BD2YWd1m+8QQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7628,7 +7628,7 @@
     },
     "node_modules/@react-spectrum/radio": {
       "version": "3.7.23",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/radio/-/radio-3.7.23.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/radio/-/radio-3.7.23.tgz",
       "integrity": "sha512-/1c86AAY3jaSaV75EEv9vdyIn321VbJLuOevRpKqLJK1IuvVm4BHCsqnqXKgfYOgxhF2tekSVPLyCDS1m7i37A==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7651,7 +7651,7 @@
     },
     "node_modules/@react-spectrum/searchfield": {
       "version": "3.8.25",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/searchfield/-/searchfield-3.8.25.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/searchfield/-/searchfield-3.8.25.tgz",
       "integrity": "sha512-7BwiWr+zsbVVHWfDI0hfV7ztQ96/EbFUSKoxrIAAu++NDcYNNtpXLxbycPgdsxJdSwmX3LgdIR3ZNh6dZZJORQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7674,7 +7674,7 @@
     },
     "node_modules/@react-spectrum/slider": {
       "version": "3.8.4",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/slider/-/slider-3.8.4.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/slider/-/slider-3.8.4.tgz",
       "integrity": "sha512-r3LE+FK8I/yvh0KUL3vOXRdu9tb6ohzlf+aubjJhYZbKTrJx0wD4rw4mrrTXxhB12aYvMHK8t/1m/DkcfSfIZw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7698,7 +7698,7 @@
     },
     "node_modules/@react-spectrum/statuslight": {
       "version": "3.5.28",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/statuslight/-/statuslight-3.5.28.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/statuslight/-/statuslight-3.5.28.tgz",
       "integrity": "sha512-dCFtqiMmLTU6JYJcKFoXrVB2vWPc6xTZgRvxN56eLjaOlTmAWPhQ+y/AlmwNp6u9rlgCVUsSuNlmIq0QYd8bFw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7716,7 +7716,7 @@
     },
     "node_modules/@react-spectrum/switch": {
       "version": "3.6.8",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/switch/-/switch-3.6.8.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/switch/-/switch-3.6.8.tgz",
       "integrity": "sha512-kp/MXCp8euC0gM3p/t/gUywxBR2jDRF3QQocNLjFo36emoE1FIR2+mXxKmiE8u/20Ao/6BoeQ9G2e+DhLCHfkg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7737,7 +7737,7 @@
     },
     "node_modules/@react-spectrum/table": {
       "version": "3.17.10",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/table/-/table-3.17.10.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/table/-/table-3.17.10.tgz",
       "integrity": "sha512-DShdGMqkdz2SY+TVhUPH/iiRkoEUUqtvS71Lj0n9NWQDGCKMMLarSHMCwPqxSAF1aGe5XHvo2tUN0iYSWrLNsQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7776,7 +7776,7 @@
     },
     "node_modules/@react-spectrum/tabs": {
       "version": "3.8.29",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/tabs/-/tabs-3.8.29.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/tabs/-/tabs-3.8.29.tgz",
       "integrity": "sha512-8vtDNvF6wuHSAnh8KyuaqwO/Aop01MWw1nTSTIV3VqFj1uThWGqJ2p2jizstXCj71m+GDES7rdxzlQbVNsn92g==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7804,7 +7804,7 @@
     },
     "node_modules/@react-spectrum/tag": {
       "version": "3.3.9",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/tag/-/tag-3.3.9.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/tag/-/tag-3.3.9.tgz",
       "integrity": "sha512-9xVb1NMIBw00C5zglyE3fLXiR6JxD+XTA/djHuiqV5BnJiTEnGjxl+88eeV5yCsCZ3/Uo9/85M4sYcISfuTPTQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7832,7 +7832,7 @@
     },
     "node_modules/@react-spectrum/text": {
       "version": "3.5.24",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/text/-/text-3.5.24.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/text/-/text-3.5.24.tgz",
       "integrity": "sha512-SF91l0G27fVlpBYjmx2pmlLv35SWcHP+kfgAazLqhmusTpirY+Um08v8RTRj0rWrpCjN6WobUQWBHUKgiCFt+g==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7851,7 +7851,7 @@
     },
     "node_modules/@react-spectrum/textfield": {
       "version": "3.14.4",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/textfield/-/textfield-3.14.4.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/textfield/-/textfield-3.14.4.tgz",
       "integrity": "sha512-MiqG4sse2OyZZVZrGA+Jyhd59wT5KMYsKCR9n5kfZWA0XBFmWCbl3472H8Bl21GMDyMfjWrEV/RDam9yMnezYA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7877,7 +7877,7 @@
     },
     "node_modules/@react-spectrum/theme-dark": {
       "version": "3.5.23",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/theme-dark/-/theme-dark-3.5.23.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/theme-dark/-/theme-dark-3.5.23.tgz",
       "integrity": "sha512-/AOAts33/Lhu/Tn5EoDsIOnEH/X7f5nLfqH/WeoUt7EIIpuEMBXYQvxO1FhaAthE4nIpqFYumjNpmUnz0tLbwA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7890,7 +7890,7 @@
     },
     "node_modules/@react-spectrum/theme-default": {
       "version": "3.5.23",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/theme-default/-/theme-default-3.5.23.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/theme-default/-/theme-default-3.5.23.tgz",
       "integrity": "sha512-AF62JsTR2LEhcrmvl4AhBv5GSbPQ314RJCS6VGT24oHVrJAQLp8sqTz8b9BWmLbTRWNTfbGFj86EXadYNdeZyQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7903,7 +7903,7 @@
     },
     "node_modules/@react-spectrum/theme-light": {
       "version": "3.4.23",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/theme-light/-/theme-light-3.4.23.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/theme-light/-/theme-light-3.4.23.tgz",
       "integrity": "sha512-+fWvRTFZg0Rrtz+GyzP+xNZqgYotmTQkDVw52qhI/mbBG21dHAmF3F2IDDhzg+rwWiLl7WlLnlZPHebilu2MSg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7916,7 +7916,7 @@
     },
     "node_modules/@react-spectrum/toast": {
       "version": "3.1.6",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/toast/-/toast-3.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/toast/-/toast-3.1.6.tgz",
       "integrity": "sha512-I2itaTN3AZp8OVQtHxpScBZpTcsB4OvoSKNUYwbXmN/F8GYSog8GHnYbQzD92ftNBcoDXkx2qYktptoTF9y2/w==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7941,7 +7941,7 @@
     },
     "node_modules/@react-spectrum/tooltip": {
       "version": "3.8.1",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/tooltip/-/tooltip-3.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/tooltip/-/tooltip-3.8.1.tgz",
       "integrity": "sha512-Em59WKFtyVguAMOONuYrVNCpSfKDvPj/ZG+4XhChqsj3acCulGxGn+jYlFfIIWOc5NCog5MHehAxO/4aC7D3jQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7966,7 +7966,7 @@
     },
     "node_modules/@react-spectrum/tree": {
       "version": "3.1.10",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/tree/-/tree-3.1.10.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/tree/-/tree-3.1.10.tgz",
       "integrity": "sha512-N/V0p3uv/NxgfNhM60lRdcffpfWX7hg/8hTU2HfFKEMvpSKUal9Gwypjy6m35JS2D69HRyVab5P0Ml8iYGW2cg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7990,7 +7990,7 @@
     },
     "node_modules/@react-spectrum/utils": {
       "version": "3.12.11",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/utils/-/utils-3.12.11.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/utils/-/utils-3.12.11.tgz",
       "integrity": "sha512-La2m3nEF2sfhGL7+9+15LU6RtMu2HR/xrUcPyHEmG7oL8EbTK8TyIVRLXYgZ51OOvOsHaEKvTchwSXbfJGW1sQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8008,7 +8008,7 @@
     },
     "node_modules/@react-spectrum/view": {
       "version": "3.6.25",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/view/-/view-3.6.25.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/view/-/view-3.6.25.tgz",
       "integrity": "sha512-uCV1BqVbZroA1XDXS3s+S20UuYNuBspwIBkHsxHsLwxM3JH4VsB27vaO2WL9LGsFWQFh8W8LvJIZ9Q7KDO6BKA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8026,7 +8026,7 @@
     },
     "node_modules/@react-spectrum/well": {
       "version": "3.4.29",
-      "resolved": "https://npm.corp.aligent.consulting/@react-spectrum/well/-/well-3.4.29.tgz",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/well/-/well-3.4.29.tgz",
       "integrity": "sha512-9wML3gt+avYT4KzImI1d59U8w+1hjIqDIFo4jkSdnd/1SlMPokFUuWp8bBUdTSmfWTihA2BxDXYkPG3LYAN/8w==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8043,7 +8043,7 @@
     },
     "node_modules/@react-stately/autocomplete": {
       "version": "3.0.0-beta.4",
-      "resolved": "https://npm.corp.aligent.consulting/@react-stately/autocomplete/-/autocomplete-3.0.0-beta.4.tgz",
+      "resolved": "https://registry.npmjs.org/@react-stately/autocomplete/-/autocomplete-3.0.0-beta.4.tgz",
       "integrity": "sha512-K2Uy7XEdseFvgwRQ8CyrYEHMupjVKEszddOapP8deNz4hntYvT1aRm0m+sKa5Kl/4kvg9c/3NZpQcrky/vRZIg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8056,7 +8056,7 @@
     },
     "node_modules/@react-stately/calendar": {
       "version": "3.9.2",
-      "resolved": "https://npm.corp.aligent.consulting/@react-stately/calendar/-/calendar-3.9.2.tgz",
+      "resolved": "https://registry.npmjs.org/@react-stately/calendar/-/calendar-3.9.2.tgz",
       "integrity": "sha512-AQj8/izwb7eY+KFqKcMLI2ygvnbAIwLuQG5KPHgJsMygFqnN4yzXKz5orGqVJnxEXLKiLPteVztx7b5EQobrtw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8072,7 +8072,7 @@
     },
     "node_modules/@react-stately/checkbox": {
       "version": "3.7.4",
-      "resolved": "https://npm.corp.aligent.consulting/@react-stately/checkbox/-/checkbox-3.7.4.tgz",
+      "resolved": "https://registry.npmjs.org/@react-stately/checkbox/-/checkbox-3.7.4.tgz",
       "integrity": "sha512-oXHMkK22CWLcmNlunDuu4p52QXYmkpx6es9AjWx/xlh3XLZdJzo/5SANioOH1QvBtwPA/c2KQy+ZBqC21NtMHw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8088,7 +8088,7 @@
     },
     "node_modules/@react-stately/collections": {
       "version": "3.12.9",
-      "resolved": "https://npm.corp.aligent.consulting/@react-stately/collections/-/collections-3.12.9.tgz",
+      "resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.12.9.tgz",
       "integrity": "sha512-2jywPMhVgMOh0XtutxPqIxFCIiLOnL/GXIrRKoBEo8M3Q24NoMRBavUrn9RTvjqNnec1i/8w1/8sq8cmCKEohA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8101,7 +8101,7 @@
     },
     "node_modules/@react-stately/color": {
       "version": "3.9.4",
-      "resolved": "https://npm.corp.aligent.consulting/@react-stately/color/-/color-3.9.4.tgz",
+      "resolved": "https://registry.npmjs.org/@react-stately/color/-/color-3.9.4.tgz",
       "integrity": "sha512-SprAP5STMg6K0jq+A3UoimsvvTCIGItUtWurS/lDRoQJYajFR8IUdz+mekU/GaXzvFhMN32dijOtFcfxnA4cfA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8121,7 +8121,7 @@
     },
     "node_modules/@react-stately/combobox": {
       "version": "3.12.2",
-      "resolved": "https://npm.corp.aligent.consulting/@react-stately/combobox/-/combobox-3.12.2.tgz",
+      "resolved": "https://registry.npmjs.org/@react-stately/combobox/-/combobox-3.12.2.tgz",
       "integrity": "sha512-h4YRmzA+s3aMwUrXm6jyWLN0BWWXUNiodArB1wC24xNdeI7S8O3mxz6G2r3Ne8AE02FXmZXs9SD30Mx5vVVuqQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8140,7 +8140,7 @@
     },
     "node_modules/@react-stately/data": {
       "version": "3.15.1",
-      "resolved": "https://npm.corp.aligent.consulting/@react-stately/data/-/data-3.15.1.tgz",
+      "resolved": "https://registry.npmjs.org/@react-stately/data/-/data-3.15.1.tgz",
       "integrity": "sha512-lchubLxCWg1Yswpe9yRYJAjmzP0eTYZe+AQyFJQRIT6axRi9Gs92RIZ7zhwLXxI0vcWpnAWADB9kD4bsos7xww==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8153,7 +8153,7 @@
     },
     "node_modules/@react-stately/datepicker": {
       "version": "3.16.0",
-      "resolved": "https://npm.corp.aligent.consulting/@react-stately/datepicker/-/datepicker-3.16.0.tgz",
+      "resolved": "https://registry.npmjs.org/@react-stately/datepicker/-/datepicker-3.16.0.tgz",
       "integrity": "sha512-mYtzKXufFVivrHjmxys3ryJFMPIQNhVqaSItmGnWv3ehxw+0HKBrROf3BFiEN4zP20euoP149ZaR4uNx90kMYw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8173,7 +8173,7 @@
     },
     "node_modules/@react-stately/disclosure": {
       "version": "3.0.10",
-      "resolved": "https://npm.corp.aligent.consulting/@react-stately/disclosure/-/disclosure-3.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/@react-stately/disclosure/-/disclosure-3.0.10.tgz",
       "integrity": "sha512-nUistLYMjBDy+yaS5H0y0Dwfcjr12zpIh7vjhQXF4wxIh3D08NRvV1NCQ0LV+IsMej/qoPJvKS4EnXHxBI3GmQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8187,7 +8187,7 @@
     },
     "node_modules/@react-stately/dnd": {
       "version": "3.7.3",
-      "resolved": "https://npm.corp.aligent.consulting/@react-stately/dnd/-/dnd-3.7.3.tgz",
+      "resolved": "https://registry.npmjs.org/@react-stately/dnd/-/dnd-3.7.3.tgz",
       "integrity": "sha512-yBtzAimyYvJWnzP80Scx7l559+43TVSyjaMpUR6/s2IjqD3XoPKgPsv7KaFUmygBTkCBGBFJn404rYgMCOsu3g==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8201,7 +8201,7 @@
     },
     "node_modules/@react-stately/flags": {
       "version": "3.1.2",
-      "resolved": "https://npm.corp.aligent.consulting/@react-stately/flags/-/flags-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@react-stately/flags/-/flags-3.1.2.tgz",
       "integrity": "sha512-2HjFcZx1MyQXoPqcBGALwWWmgFVUk2TuKVIQxCbRq7fPyWXIl6VHcakCLurdtYC2Iks7zizvz0Idv48MQ38DWg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8210,7 +8210,7 @@
     },
     "node_modules/@react-stately/form": {
       "version": "3.2.3",
-      "resolved": "https://npm.corp.aligent.consulting/@react-stately/form/-/form-3.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/@react-stately/form/-/form-3.2.3.tgz",
       "integrity": "sha512-NPvjJtns1Pq9uvqeRJCf8HIdVmOm2ARLYQ2F/sqXj1w5IChJ4oWL4Xzvj29/zBitgE1vVjDhnrnwSfNlHZGX0g==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8223,7 +8223,7 @@
     },
     "node_modules/@react-stately/grid": {
       "version": "3.11.8",
-      "resolved": "https://npm.corp.aligent.consulting/@react-stately/grid/-/grid-3.11.8.tgz",
+      "resolved": "https://registry.npmjs.org/@react-stately/grid/-/grid-3.11.8.tgz",
       "integrity": "sha512-tCabR5U7ype+uEElS5Chv5n6ntUv3drXa9DwebjO05cFevUmjTkEfYPJWixpgX4UlCCvjdUFgzeQlJF+gCiozg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8239,7 +8239,7 @@
     },
     "node_modules/@react-stately/layout": {
       "version": "4.5.3",
-      "resolved": "https://npm.corp.aligent.consulting/@react-stately/layout/-/layout-4.5.3.tgz",
+      "resolved": "https://registry.npmjs.org/@react-stately/layout/-/layout-4.5.3.tgz",
       "integrity": "sha512-BDYnvO2AKzvWfxxVM96kif3qCynsA+XcNoQC+T77exH+LLT8zlK9oOdarZXTlok/eZmjs6+5wmjq51PeL6eM5w==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8258,7 +8258,7 @@
     },
     "node_modules/@react-stately/list": {
       "version": "3.13.3",
-      "resolved": "https://npm.corp.aligent.consulting/@react-stately/list/-/list-3.13.3.tgz",
+      "resolved": "https://registry.npmjs.org/@react-stately/list/-/list-3.13.3.tgz",
       "integrity": "sha512-xN0v7rzhIKshhcshOzx+ZgVngXnGCtMPRdhoDLGaHzQy5YfxvKBMNLCnr5Lm4T1U/kIvHbyzxmr5uwmH8WxoIg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8274,7 +8274,7 @@
     },
     "node_modules/@react-stately/menu": {
       "version": "3.9.10",
-      "resolved": "https://npm.corp.aligent.consulting/@react-stately/menu/-/menu-3.9.10.tgz",
+      "resolved": "https://registry.npmjs.org/@react-stately/menu/-/menu-3.9.10.tgz",
       "integrity": "sha512-dY9FzjQ+6iNInVujZPyMklDGoSbaoO0yguUnALAY+yfkPAyStEElfm4aXZgRfNKOTNHe9E34oV7qefSYsclvTg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8289,7 +8289,7 @@
     },
     "node_modules/@react-stately/numberfield": {
       "version": "3.10.4",
-      "resolved": "https://npm.corp.aligent.consulting/@react-stately/numberfield/-/numberfield-3.10.4.tgz",
+      "resolved": "https://registry.npmjs.org/@react-stately/numberfield/-/numberfield-3.10.4.tgz",
       "integrity": "sha512-EniHHwXOw/Ta0x5j61OvldDAvLoi/8xOo//bzrqwnDvf2/1IKGFMD9CHs7HYhQw+9oNl3Q2V1meOTNPc4PvoMQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8305,7 +8305,7 @@
     },
     "node_modules/@react-stately/overlays": {
       "version": "3.6.22",
-      "resolved": "https://npm.corp.aligent.consulting/@react-stately/overlays/-/overlays-3.6.22.tgz",
+      "resolved": "https://registry.npmjs.org/@react-stately/overlays/-/overlays-3.6.22.tgz",
       "integrity": "sha512-sWBnuy5dqVp8d+1e+ABTRVB3YBcOW86/90pF5PWY44au3bUFXVSUBO2QMdR/6JtojDoPRmrjufonI19/Zs/20w==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8319,7 +8319,7 @@
     },
     "node_modules/@react-stately/radio": {
       "version": "3.11.4",
-      "resolved": "https://npm.corp.aligent.consulting/@react-stately/radio/-/radio-3.11.4.tgz",
+      "resolved": "https://registry.npmjs.org/@react-stately/radio/-/radio-3.11.4.tgz",
       "integrity": "sha512-3svsW5VxJA5/p1vO+Qlxv+7Jq9g7f4rqX9Rbqdfd+pH7ykHaV0CUKkSRMaWfcY8Vgaf2xmcc6dvusPRqKX8T1A==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8335,7 +8335,7 @@
     },
     "node_modules/@react-stately/searchfield": {
       "version": "3.5.18",
-      "resolved": "https://npm.corp.aligent.consulting/@react-stately/searchfield/-/searchfield-3.5.18.tgz",
+      "resolved": "https://registry.npmjs.org/@react-stately/searchfield/-/searchfield-3.5.18.tgz",
       "integrity": "sha512-C3/1wOON5oK0QBljj0vSbHm/IWgd29NxB+7zT1JjZcxtbcFxCj4HOxKdnPCT/d8Pojb0YS26QgKzatLZ0NnhgQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8349,7 +8349,7 @@
     },
     "node_modules/@react-stately/select": {
       "version": "3.9.1",
-      "resolved": "https://npm.corp.aligent.consulting/@react-stately/select/-/select-3.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/@react-stately/select/-/select-3.9.1.tgz",
       "integrity": "sha512-CJQRqv8Dg+0RRvcig3a2YfY6POJIscDINvidRF31yK6J72rsP01dY3ria9aJjizNDHR9Q5dWFp/z+ii0cOTWIQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8367,7 +8367,7 @@
     },
     "node_modules/@react-stately/selection": {
       "version": "3.20.8",
-      "resolved": "https://npm.corp.aligent.consulting/@react-stately/selection/-/selection-3.20.8.tgz",
+      "resolved": "https://registry.npmjs.org/@react-stately/selection/-/selection-3.20.8.tgz",
       "integrity": "sha512-V1kRN1NLW+i/3Xv+Q0pN9OzuM0zFEW9mdXOOOq7l+YL6hFjqIjttT2/q4KoyiNV3W0hfoRFSTQ7XCgqnqtwEng==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8382,7 +8382,7 @@
     },
     "node_modules/@react-stately/slider": {
       "version": "3.7.4",
-      "resolved": "https://npm.corp.aligent.consulting/@react-stately/slider/-/slider-3.7.4.tgz",
+      "resolved": "https://registry.npmjs.org/@react-stately/slider/-/slider-3.7.4.tgz",
       "integrity": "sha512-cSOYSx2nsOQejMg6Ql0+GUpqAiPwRA5teYXUghNvuBDtVxnd4l2rnXs54Ww48tU43xf2+L3kkmMofThjABoEPw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8397,7 +8397,7 @@
     },
     "node_modules/@react-stately/table": {
       "version": "3.15.3",
-      "resolved": "https://npm.corp.aligent.consulting/@react-stately/table/-/table-3.15.3.tgz",
+      "resolved": "https://registry.npmjs.org/@react-stately/table/-/table-3.15.3.tgz",
       "integrity": "sha512-W1wR0O/PmdD8hCUFIAelHICjUX/Ii6ZldPlH6EILr9olyGpoCaY7XmnyG7kii1aANuQGBeskjJdXvS6LX/gyDw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8417,7 +8417,7 @@
     },
     "node_modules/@react-stately/tabs": {
       "version": "3.8.8",
-      "resolved": "https://npm.corp.aligent.consulting/@react-stately/tabs/-/tabs-3.8.8.tgz",
+      "resolved": "https://registry.npmjs.org/@react-stately/tabs/-/tabs-3.8.8.tgz",
       "integrity": "sha512-BZImWT+pHZitImRQkoL7jVhTtpGPSra1Rhh4pi8epzwogeqseEIEpuWpQebjQP74r1kfNi/iT2p5Qb31eWfh1Q==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8432,7 +8432,7 @@
     },
     "node_modules/@react-stately/toast": {
       "version": "3.1.3",
-      "resolved": "https://npm.corp.aligent.consulting/@react-stately/toast/-/toast-3.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/@react-stately/toast/-/toast-3.1.3.tgz",
       "integrity": "sha512-mT9QJKmD523lqFpOp0VWZ6QHZENFK7HrodnNJDVc7g616s5GNmemdlkITV43fSY3tHeThCVvPu+Uzh7RvQ9mpQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8445,7 +8445,7 @@
     },
     "node_modules/@react-stately/toggle": {
       "version": "3.9.4",
-      "resolved": "https://npm.corp.aligent.consulting/@react-stately/toggle/-/toggle-3.9.4.tgz",
+      "resolved": "https://registry.npmjs.org/@react-stately/toggle/-/toggle-3.9.4.tgz",
       "integrity": "sha512-tjWsshRJtHC+PI5NYMlnDlV/BTo1eWq6fmR6x1mXlQfKuKGTJRzhgJyaQ2mc5K+LkifD7fchOhfapHCrRlzwMg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8460,7 +8460,7 @@
     },
     "node_modules/@react-stately/tooltip": {
       "version": "3.5.10",
-      "resolved": "https://npm.corp.aligent.consulting/@react-stately/tooltip/-/tooltip-3.5.10.tgz",
+      "resolved": "https://registry.npmjs.org/@react-stately/tooltip/-/tooltip-3.5.10.tgz",
       "integrity": "sha512-GauUdc6Of08Np2iUw4xx/DdgpvszS9CxJWYcRnNyAAGPLQrmniVrpJvb0EUKQTP9sUSci1SlmpvJh4SNZx26Bw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8474,7 +8474,7 @@
     },
     "node_modules/@react-stately/tree": {
       "version": "3.9.5",
-      "resolved": "https://npm.corp.aligent.consulting/@react-stately/tree/-/tree-3.9.5.tgz",
+      "resolved": "https://registry.npmjs.org/@react-stately/tree/-/tree-3.9.5.tgz",
       "integrity": "sha512-UpvBlzL/MpFdOepDg+cohI/zvw8DEVM8cXY/OZ8tKUXWpew1HpUglwnAI3ivm0L2k9laUIB9siW0g04ZWiH9Lg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8490,7 +8490,7 @@
     },
     "node_modules/@react-stately/utils": {
       "version": "3.11.0",
-      "resolved": "https://npm.corp.aligent.consulting/@react-stately/utils/-/utils-3.11.0.tgz",
+      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.11.0.tgz",
       "integrity": "sha512-8LZpYowJ9eZmmYLpudbo/eclIRnbhWIJZ994ncmlKlouNzKohtM8qTC6B1w1pwUbiwGdUoyzLuQbeaIor5Dvcw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8502,7 +8502,7 @@
     },
     "node_modules/@react-stately/virtualizer": {
       "version": "4.4.5",
-      "resolved": "https://npm.corp.aligent.consulting/@react-stately/virtualizer/-/virtualizer-4.4.5.tgz",
+      "resolved": "https://registry.npmjs.org/@react-stately/virtualizer/-/virtualizer-4.4.5.tgz",
       "integrity": "sha512-MP33zys3nRYTk/+3BPchxlil9GrwbMksc3XuvNACeZqYEA/oEidsHffgPL+LY0iitKCmQE6pg49MI5HvBuOd2w==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8516,7 +8516,7 @@
     },
     "node_modules/@react-types/actionbar": {
       "version": "3.1.20",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/actionbar/-/actionbar-3.1.20.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/actionbar/-/actionbar-3.1.20.tgz",
       "integrity": "sha512-K3fajms4FmeVnUAXuJ7iwhtS2Lh8hHFZCqCrvHdHqzRyIsx7vMRvITXyhHnIEuIXDCHb2k7cSzFJzn9kvJLosw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8528,7 +8528,7 @@
     },
     "node_modules/@react-types/actiongroup": {
       "version": "3.4.22",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/actiongroup/-/actiongroup-3.4.22.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/actiongroup/-/actiongroup-3.4.22.tgz",
       "integrity": "sha512-J3MIpK3a+AXmyUTd2+bHn3J2XcZV1oJpZxFxmWonitiIvbyEZbiZHeMrBPxHST60BxVGzQK/J+mROZNjxIRWpg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8540,7 +8540,7 @@
     },
     "node_modules/@react-types/autocomplete": {
       "version": "3.0.0-alpha.37",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/autocomplete/-/autocomplete-3.0.0-alpha.37.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/autocomplete/-/autocomplete-3.0.0-alpha.37.tgz",
       "integrity": "sha512-9KkL/UEUHIqp4OD4PffeZPiRV93ZBKq84sBrzTbTIPN+os+N+Lfz45Mg67NM2RumR/KQSVE0gZp7OA0eOvxPYA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8554,7 +8554,7 @@
     },
     "node_modules/@react-types/avatar": {
       "version": "3.0.20",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/avatar/-/avatar-3.0.20.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/avatar/-/avatar-3.0.20.tgz",
       "integrity": "sha512-zm6gQ542PjwSOklWWrc1fNAqCKSercDw4uEg59zMUNa1EdOToDqAIWjE1yTnG8TmK9qg49BeNhdgwQM6SvuoJA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8566,7 +8566,7 @@
     },
     "node_modules/@react-types/badge": {
       "version": "3.1.22",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/badge/-/badge-3.1.22.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/badge/-/badge-3.1.22.tgz",
       "integrity": "sha512-X25PoFrMWv7JDzwciMW4Y5pxGP47DaKr/5ZNnxu6wmOE+OrTcIDsoMCH3Jw2RZLeQKSYQOIPLSpzFEAZAIView==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8578,7 +8578,7 @@
     },
     "node_modules/@react-types/breadcrumbs": {
       "version": "3.7.18",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/breadcrumbs/-/breadcrumbs-3.7.18.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/breadcrumbs/-/breadcrumbs-3.7.18.tgz",
       "integrity": "sha512-zwltqx2XSELBRQeuCraxrdfT4fpIOVu6eQXsZ4RhWlsT7DLhzj3pUGkxdPDAMfYaVdyNBqc+nhiAnCwz6tUJ8A==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8591,7 +8591,7 @@
     },
     "node_modules/@react-types/button": {
       "version": "3.15.0",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/button/-/button-3.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/button/-/button-3.15.0.tgz",
       "integrity": "sha512-X/K2/Oeuq7Hi8nMIzx4/YlZuvWFiSOHZt27p4HmThCnNO/9IDFPmvPrpkYjWN5eN9Nuk+P5vZUb4A7QJgYpvGA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8603,7 +8603,7 @@
     },
     "node_modules/@react-types/buttongroup": {
       "version": "3.3.22",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/buttongroup/-/buttongroup-3.3.22.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/buttongroup/-/buttongroup-3.3.22.tgz",
       "integrity": "sha512-m9BR19zcUuD6adUKN3e/bKgCdL/YWLySq0IW9vlShKiZBcZ7a2iqYgi0JAmDTSsmzingvQxmMIkDL+8IdxY5Mg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8615,7 +8615,7 @@
     },
     "node_modules/@react-types/calendar": {
       "version": "3.8.2",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/calendar/-/calendar-3.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/calendar/-/calendar-3.8.2.tgz",
       "integrity": "sha512-QbPFhvBQfrsz3x1Nnatr5SL+8XtbxvP4obESFuDrKmsqaaAv+jG5vwLiPTKp6Z3L+MWkCvKavBPuW+byhq+69A==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8628,7 +8628,7 @@
     },
     "node_modules/@react-types/checkbox": {
       "version": "3.10.3",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/checkbox/-/checkbox-3.10.3.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/checkbox/-/checkbox-3.10.3.tgz",
       "integrity": "sha512-Xw4jHG7uK352Wc18XXzdzmtr3Xjg8d2tPoBGNgsw39f92EY2UpoDAPHxYR0BaDe04lGfAn6YwVivI4OGVbjXIg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8640,7 +8640,7 @@
     },
     "node_modules/@react-types/color": {
       "version": "3.1.3",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/color/-/color-3.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/color/-/color-3.1.3.tgz",
       "integrity": "sha512-XM0x8iZpAf036w9qceD2RFroehLxKRwkVer7EvdJNs8K8iUN8TuhCagzsomiSJtyYh5MFysEVQ2ir85toiAFyw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8653,7 +8653,7 @@
     },
     "node_modules/@react-types/combobox": {
       "version": "3.13.11",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/combobox/-/combobox-3.13.11.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/combobox/-/combobox-3.13.11.tgz",
       "integrity": "sha512-5/tdmTAvqPpiWzEeaV7uLLSbSTkkoQ1mVz6NfKMPuw4ZBkY3lPc9JDkkQjY/JrquZao+KY4Dx8ZIoS0NqkrFrw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8665,7 +8665,7 @@
     },
     "node_modules/@react-types/contextualhelp": {
       "version": "3.2.23",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/contextualhelp/-/contextualhelp-3.2.23.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/contextualhelp/-/contextualhelp-3.2.23.tgz",
       "integrity": "sha512-wXTa1nnkt1Ix13Cv3APtYU6jT6qv88Kv6c343U7gSZugMEq0YEgibpYZPpCtQ2EyiQNGopweDR3SJSpZjaaQtw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8678,7 +8678,7 @@
     },
     "node_modules/@react-types/datepicker": {
       "version": "3.13.4",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/datepicker/-/datepicker-3.13.4.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/datepicker/-/datepicker-3.13.4.tgz",
       "integrity": "sha512-B5sAPoYZfluDBpgVK3ADlHbXBKRkFCQFO18Bs091IvRRwqzfoO/uf+/9UpXMw+BEF4pciLf0/kdiVQTvI3MzlA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8693,7 +8693,7 @@
     },
     "node_modules/@react-types/dialog": {
       "version": "3.5.23",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/dialog/-/dialog-3.5.23.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/dialog/-/dialog-3.5.23.tgz",
       "integrity": "sha512-3tMzweYuaDOaufF5tZPMgXSA0pPFJNgdg89YRITh0wMXMG0pm+tAKVQJL1TSLLhOiLCEL08V8M/AK67dBdr2IA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8706,7 +8706,7 @@
     },
     "node_modules/@react-types/divider": {
       "version": "3.3.22",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/divider/-/divider-3.3.22.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/divider/-/divider-3.3.22.tgz",
       "integrity": "sha512-PZ4Xt86PV2QL1ynTMc9hLW7InlbkQ93Hnr2nSyJKsagTI6YGHZQSUhiPPuJbCJ4WuEMu3V0Boqzzcc1qRSluEg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8718,7 +8718,7 @@
     },
     "node_modules/@react-types/form": {
       "version": "3.7.17",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/form/-/form-3.7.17.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/form/-/form-3.7.17.tgz",
       "integrity": "sha512-wBFRJ3jehHw2X2Td/KwUNxFWOqXCK7OTGG9A+W3ZI3nDGyflHQpIjqKCKV1jRySs6sv7huiPckJ7ScDleCKf7w==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8730,7 +8730,7 @@
     },
     "node_modules/@react-types/grid": {
       "version": "3.3.7",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/grid/-/grid-3.3.7.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/grid/-/grid-3.3.7.tgz",
       "integrity": "sha512-riET3xeKPTcRWQy6hYCMxdbdL3yubPY5Ow66b2GA2rEqoYvmDBniYXAM2Oh+q9s+YgnAP7qJK++ym8NljvHiLA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8742,7 +8742,7 @@
     },
     "node_modules/@react-types/illustratedmessage": {
       "version": "3.3.22",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/illustratedmessage/-/illustratedmessage-3.3.22.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/illustratedmessage/-/illustratedmessage-3.3.22.tgz",
       "integrity": "sha512-WjCen1aC03VVdRv7Lzgl8E2VEFnTgP/zhVIucoFiGqcWZhcS2wFtGU9YmuO5Jv/P7u5mwLYiKOkbm7IqrD9ybQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8754,7 +8754,7 @@
     },
     "node_modules/@react-types/image": {
       "version": "3.5.3",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/image/-/image-3.5.3.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/image/-/image-3.5.3.tgz",
       "integrity": "sha512-8/VXe2oRpSrTpykD6TF7lJrFmILwUZCzYMaS9ZKSK5xXtb18UXg3lY1LtgRHw6cMnf6lvZ6rkuSPacnmh4uCxA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8766,7 +8766,7 @@
     },
     "node_modules/@react-types/label": {
       "version": "3.9.16",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/label/-/label-3.9.16.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/label/-/label-3.9.16.tgz",
       "integrity": "sha512-JhH6nIC0Dg0+ITjgKdg1NK0NgMy7Rs4Tl2wQVeow1Ofb5cODbUYFM1/mIOW3Rap+tv4mC+ebhr+p2ofwJAYqxQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8778,7 +8778,7 @@
     },
     "node_modules/@react-types/layout": {
       "version": "3.3.28",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/layout/-/layout-3.3.28.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/layout/-/layout-3.3.28.tgz",
       "integrity": "sha512-GZRA507QGXoPJIB2xOrriY/PBhsD68Yc+14zih4t44jQNoi6ltuQMYqdmVb6c6YoNT1MKQAs6NZcGMtyHZs/aA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8790,7 +8790,7 @@
     },
     "node_modules/@react-types/link": {
       "version": "3.6.6",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/link/-/link-3.6.6.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/link/-/link-3.6.6.tgz",
       "integrity": "sha512-M6WXxUJFmiF6GNu7xUH0uHj0jsorFBN6npkfSCNM4puStC8NbUT2+ZPySQyZXCoHMQ89g6qZ6vCc8QduVkTE7Q==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8802,7 +8802,7 @@
     },
     "node_modules/@react-types/listbox": {
       "version": "3.7.5",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/listbox/-/listbox-3.7.5.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/listbox/-/listbox-3.7.5.tgz",
       "integrity": "sha512-Cn+yNip+YZBaGzu+z5xPNgmfSupnLl+li7uG5hRc+EArkk8/G42myRXz6M8wPrLM1bFAq3r85tAbyoXVmKG5Jw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8814,7 +8814,7 @@
     },
     "node_modules/@react-types/menu": {
       "version": "3.10.6",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/menu/-/menu-3.10.6.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/menu/-/menu-3.10.6.tgz",
       "integrity": "sha512-OJTznQ4xE/VddBJU+HO4x5tceSOdyQhiHA1bREE1aHl+PcgHOUZLdMjXp1zFaGF16HhItHJaxpifJ4hzf4hWQA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8827,7 +8827,7 @@
     },
     "node_modules/@react-types/meter": {
       "version": "3.4.14",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/meter/-/meter-3.4.14.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/meter/-/meter-3.4.14.tgz",
       "integrity": "sha512-rNw0Do2AM3zLGZ0pSWweViuddg1uW99PWzE6RQXE8nsTHTeiwDZt9SYGdObEnjd+nJ3YzemqekG0Kqt93iNBcA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8839,7 +8839,7 @@
     },
     "node_modules/@react-types/numberfield": {
       "version": "3.8.17",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/numberfield/-/numberfield-3.8.17.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/numberfield/-/numberfield-3.8.17.tgz",
       "integrity": "sha512-Q9n24OaSMXrebMowbtowmHLNclknN3XkcBIaYMwA2BIGIl+fZFnI8MERM0pG87W+wki6FepDExsDW9YxQF4pnw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8851,7 +8851,7 @@
     },
     "node_modules/@react-types/overlays": {
       "version": "3.9.3",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/overlays/-/overlays-3.9.3.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/overlays/-/overlays-3.9.3.tgz",
       "integrity": "sha512-LzetThNNk8T26pQRbs1I7+isuFhdFYREy7wJCsZmbB0FnZgCukGTfOtThZWv+ry11veyVJiX68jfl4SV6ACTWA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8863,7 +8863,7 @@
     },
     "node_modules/@react-types/progress": {
       "version": "3.5.17",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/progress/-/progress-3.5.17.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/progress/-/progress-3.5.17.tgz",
       "integrity": "sha512-JtiGlek6QS04bFrRj1WfChjPNr7+3/+pd6yZayXGUkQUPHt1Z/cFnv3QZ/tSQTdUt1XXmjnCak9ZH9JQBqe64Q==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8875,7 +8875,7 @@
     },
     "node_modules/@react-types/provider": {
       "version": "3.8.14",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/provider/-/provider-3.8.14.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/provider/-/provider-3.8.14.tgz",
       "integrity": "sha512-kzk2p19aAiOX2VKU8Jto+SOvA6q3D+QHQuyfvQvCRWsWh4DCGYstaXEv6MLRlccm3B/JqHdj1f2Cyb5VsvgE2Q==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8887,7 +8887,7 @@
     },
     "node_modules/@react-types/radio": {
       "version": "3.9.3",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/radio/-/radio-3.9.3.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/radio/-/radio-3.9.3.tgz",
       "integrity": "sha512-w2BrMGIiZxYXPCnnB2NQyifwE/rRFMIW87MyawrKO9zPSbnDkqLIHAAtqmlNk2zkz1ZEWjk9opNsuztjP7D4sA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8899,7 +8899,7 @@
     },
     "node_modules/@react-types/searchfield": {
       "version": "3.6.7",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/searchfield/-/searchfield-3.6.7.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/searchfield/-/searchfield-3.6.7.tgz",
       "integrity": "sha512-POo3spZcYD14aqo0f4eNbymJ8w9EKrlu0pOOjYYWI2P0GUSRmib9cBA9xZFhvRGHuNlHo3ePjeFitYQI7L3g1g==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8912,7 +8912,7 @@
     },
     "node_modules/@react-types/select": {
       "version": "3.12.1",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/select/-/select-3.12.1.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/select/-/select-3.12.1.tgz",
       "integrity": "sha512-PtIUymvQNIIzgr+piJtK/8gbH7akWtbswIbfoADPSxtZEd1/vfUIO0s8c750s3XYNlmx/4DrhugQsLYwgC35yg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8924,7 +8924,7 @@
     },
     "node_modules/@react-types/shared": {
       "version": "3.33.0",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/shared/-/shared-3.33.0.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.33.0.tgz",
       "integrity": "sha512-xuUpP6MyuPmJtzNOqF5pzFUIHH2YogyOQfUQHag54PRmWB7AbjuGWBUv0l1UDmz6+AbzAYGmDVAzcRDOu2PFpw==",
       "license": "Apache-2.0",
       "peerDependencies": {
@@ -8933,7 +8933,7 @@
     },
     "node_modules/@react-types/slider": {
       "version": "3.8.3",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/slider/-/slider-3.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/slider/-/slider-3.8.3.tgz",
       "integrity": "sha512-HCDegYiUA27CcJKvFwgpR8ktFKf2nAirXqQEgVPV4uxk6JIeiRx41yqM/xPJGfmaqa7BARYARLT41yN2V8Kadg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8945,7 +8945,7 @@
     },
     "node_modules/@react-types/statuslight": {
       "version": "3.3.22",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/statuslight/-/statuslight-3.3.22.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/statuslight/-/statuslight-3.3.22.tgz",
       "integrity": "sha512-vWWH2O2MhIxMskptu5vJyYtU9YweWk5E6GpCtxaL42qAnc+9Hh46kh8eGolE5wMeUGWJj+rMKHzQcVz3iIh/Yw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8957,7 +8957,7 @@
     },
     "node_modules/@react-types/switch": {
       "version": "3.5.16",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/switch/-/switch-3.5.16.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/switch/-/switch-3.5.16.tgz",
       "integrity": "sha512-6fynclkyg0wGHo3f1bwk4Z+gZZEg0Z63iP5TFhgHWdZ8W+Uq6F3u7V4IgQpuJ2NleL1c2jy2/CKdS9v06ac2Og==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8969,7 +8969,7 @@
     },
     "node_modules/@react-types/table": {
       "version": "3.13.5",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/table/-/table-3.13.5.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/table/-/table-3.13.5.tgz",
       "integrity": "sha512-4/CixlNmXSuJuX2IKuUlgNd/dEgNh3WvfE/bdwuI1t5JBdShP9tHIzSkgZbrzE2xX46NeA2xq4vXNO5kBv+QDA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8982,7 +8982,7 @@
     },
     "node_modules/@react-types/tabs": {
       "version": "3.3.21",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/tabs/-/tabs-3.3.21.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/tabs/-/tabs-3.3.21.tgz",
       "integrity": "sha512-Dq9bKI62rHoI4LGGcBGlZ5s0aSwB0G4Y8o0r7hQZvf1eZWc9fmqdAdTTaGG/RUyhMIGRYWl5RRUBUuC5RmaO6w==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8994,7 +8994,7 @@
     },
     "node_modules/@react-types/text": {
       "version": "3.3.22",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/text/-/text-3.3.22.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/text/-/text-3.3.22.tgz",
       "integrity": "sha512-w0LdG39MXwSB9SdE627TM/jkRY1KsmFF60zY8N1caLyunxB87UBhFXmDMTKBhuIQW5h/H0Z+PCy0BNYWXIzqyQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -9006,7 +9006,7 @@
     },
     "node_modules/@react-types/textfield": {
       "version": "3.12.7",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/textfield/-/textfield-3.12.7.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/textfield/-/textfield-3.12.7.tgz",
       "integrity": "sha512-ddiacsS6sLFtAn2/fym7lR8nbdsLgPfelNDcsDqHiu6XUHh5TCNe8ItXHFaIiyfnKTH8uJqZrSli4wfAYNfMsw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -9018,7 +9018,7 @@
     },
     "node_modules/@react-types/tooltip": {
       "version": "3.5.1",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/tooltip/-/tooltip-3.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/tooltip/-/tooltip-3.5.1.tgz",
       "integrity": "sha512-h6xOAWbWUJKs9CzcCyzSPATLHq7W5dS866HkXLrtCrRDShLuzQnojZnctD2tKtNt17990hjnOhl36GUBuO5kyw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -9031,7 +9031,7 @@
     },
     "node_modules/@react-types/view": {
       "version": "3.4.22",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/view/-/view-3.4.22.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/view/-/view-3.4.22.tgz",
       "integrity": "sha512-tIKu1PxR/kDN3/vbkCJhn17OG6SBxSA/x966/XbLCS6tEmYuP0qu0f72htoDAJ2YQEEUAim86lPjpE0PCgQ2PQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -9043,7 +9043,7 @@
     },
     "node_modules/@react-types/well": {
       "version": "3.3.22",
-      "resolved": "https://npm.corp.aligent.consulting/@react-types/well/-/well-3.3.22.tgz",
+      "resolved": "https://registry.npmjs.org/@react-types/well/-/well-3.3.22.tgz",
       "integrity": "sha512-J2o4bXHkOjl1J4A+Hnr+6oD03T4LwnQ0iMhNU75NSUVXferOSa09M+5ANUalo37bUhxAJSV6Z3Y0Y/oQTabphw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -9110,7 +9110,7 @@
     },
     "node_modules/@spectrum-icons/ui": {
       "version": "3.6.22",
-      "resolved": "https://npm.corp.aligent.consulting/@spectrum-icons/ui/-/ui-3.6.22.tgz",
+      "resolved": "https://registry.npmjs.org/@spectrum-icons/ui/-/ui-3.6.22.tgz",
       "integrity": "sha512-+eCsRq3RP0QclNsUTb709TqKKXi5weCsrSOEBNV4Up36s/56lEprk7BQcS5Q3yxjH/fjmpw4e53bnl6a+teZUw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -9127,7 +9127,7 @@
     },
     "node_modules/@spectrum-icons/workflow": {
       "version": "4.2.27",
-      "resolved": "https://npm.corp.aligent.consulting/@spectrum-icons/workflow/-/workflow-4.2.27.tgz",
+      "resolved": "https://registry.npmjs.org/@spectrum-icons/workflow/-/workflow-4.2.27.tgz",
       "integrity": "sha512-8EY3VA2NxuXmkH3QgCe5A9QOsGTmeKPspPvZ3D+6JYXwr7k7/xx3Pt0gLy1NKvTNz5AkFNa2+znAa2enbpo5JA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -9785,7 +9785,7 @@
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.18",
-      "resolved": "https://npm.corp.aligent.consulting/@swc/helpers/-/helpers-0.5.18.tgz",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
       "integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -11537,7 +11537,7 @@
     },
     "node_modules/client-only": {
       "version": "0.0.1",
-      "resolved": "https://npm.corp.aligent.consulting/client-only/-/client-only-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
@@ -11591,7 +11591,7 @@
     },
     "node_modules/clsx": {
       "version": "2.1.1",
-      "resolved": "https://npm.corp.aligent.consulting/clsx/-/clsx-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "license": "MIT",
       "engines": {
@@ -11928,7 +11928,7 @@
     },
     "node_modules/decimal.js": {
       "version": "10.6.0",
-      "resolved": "https://npm.corp.aligent.consulting/decimal.js/-/decimal.js-10.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "license": "MIT"
     },
@@ -12043,7 +12043,7 @@
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
-      "resolved": "https://npm.corp.aligent.consulting/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
       "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
       "license": "MIT",
       "dependencies": {
@@ -13773,7 +13773,7 @@
     },
     "node_modules/intl-messageformat": {
       "version": "10.7.18",
-      "resolved": "https://npm.corp.aligent.consulting/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
       "integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -16698,7 +16698,7 @@
     },
     "node_modules/react-aria": {
       "version": "3.46.0",
-      "resolved": "https://npm.corp.aligent.consulting/react-aria/-/react-aria-3.46.0.tgz",
+      "resolved": "https://registry.npmjs.org/react-aria/-/react-aria-3.46.0.tgz",
       "integrity": "sha512-We0diSsMK35jw53JFjgF9w8obBjehAUI/TRiynnzSrjRd9eoHYQcecHlptke/HEFxvya/Gcm+LA21Im1+qnIeQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -16752,7 +16752,7 @@
     },
     "node_modules/react-aria-components": {
       "version": "1.15.1",
-      "resolved": "https://npm.corp.aligent.consulting/react-aria-components/-/react-aria-components-1.15.1.tgz",
+      "resolved": "https://registry.npmjs.org/react-aria-components/-/react-aria-components-1.15.1.tgz",
       "integrity": "sha512-irGhZ+vBvoY9xJHf/qzPLLwFZ8cBUrYwPERGhgjE62dy/RXMUiEW+1DeTHz0OvtjbvFbhNp/I7XM9IaBvmLALg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -16811,7 +16811,7 @@
     },
     "node_modules/react-router": {
       "version": "7.13.0",
-      "resolved": "https://npm.corp.aligent.consulting/react-router/-/react-router-7.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.0.tgz",
       "integrity": "sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw==",
       "license": "MIT",
       "dependencies": {
@@ -16846,7 +16846,7 @@
     },
     "node_modules/react-stately": {
       "version": "3.44.0",
-      "resolved": "https://npm.corp.aligent.consulting/react-stately/-/react-stately-3.44.0.tgz",
+      "resolved": "https://registry.npmjs.org/react-stately/-/react-stately-3.44.0.tgz",
       "integrity": "sha512-Il3trIp2Mo1SSa9PhQFraqOpC74zEFmwuMAlu5Fj3qdtihJOKOFqoyDl7ALRrVfnvCkau6rui155d/NMKvd+RQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -16883,7 +16883,7 @@
     },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
-      "resolved": "https://npm.corp.aligent.consulting/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
       "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -18758,7 +18758,7 @@
     },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
-      "resolved": "https://npm.corp.aligent.consulting/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "license": "MIT",
       "peerDependencies": {


### PR DESCRIPTION
**Description of the proposed changes**
In a previous update, it appears someone had their config pointing to the Aligent private registry. As a result, a number of public packages are linked there, making it difficult to update automatically for things like security alerts.

This change simply points all resolved packages correctly back to the default npm registry.

- **Screenshots (if applicable)**
- N/A

- **Other solutions considered (if any)**
N/A

**Notes to reviewers**

🛈 When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback
